### PR TITLE
Make State methods return snapshots of objects to prevent data races

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -1,0 +1,210 @@
+package discord
+
+// Clone returns a clone of this User.
+func (u *User) Clone() *User {
+	if u == nil {
+		return nil
+	}
+
+	return &User{
+		ID:            u.ID,
+		Username:      u.Username,
+		Discriminator: u.Discriminator,
+		Avatar:        u.Avatar,
+		Bot:           u.Bot,
+		MFAEnabled:    u.MFAEnabled,
+		Verified:      u.Verified,
+		Email:         u.Email,
+	}
+}
+
+// Clone returns a clone of this Guild.
+func (g *Guild) Clone() *Guild {
+	if g == nil {
+		return nil
+	}
+
+	guild := &Guild{
+		ID:                          g.ID,
+		Name:                        g.Name,
+		Splash:                      g.Icon,
+		Owner:                       g.Owner,
+		OwnerID:                     g.OwnerID,
+		Permissions:                 g.Permissions,
+		Region:                      g.Region,
+		AFKChannelID:                g.AFKChannelID,
+		AFKTimeout:                  g.AFKTimeout,
+		EmbedEnabled:                g.EmbedEnabled,
+		EmbedChannelID:              g.EmbedChannelID,
+		VerificationLevel:           g.VerificationLevel,
+		DefaultMessageNotifications: g.DefaultMessageNotifications,
+		ExplicitContentFilter:       g.ExplicitContentFilter,
+		MFALevel:                    g.MFALevel,
+		ApplicationID:               g.ApplicationID,
+		WidgetEnabled:               g.WidgetEnabled,
+		WidgetChannelID:             g.WidgetChannelID,
+		SystemChannelID:             g.SystemChannelID,
+		JoinedAt:                    g.JoinedAt,
+		Large:                       g.Large,
+		Unavailable:                 g.Unavailable,
+		MemberCount:                 g.MemberCount,
+	}
+
+	for i := 0; i < len(g.Roles); i++ {
+		role := g.Roles[i].Clone()
+		guild.Roles = append(guild.Roles, *role)
+	}
+
+	for i := 0; i < len(g.Emojis); i++ {
+		emoji := g.Emojis[i].Clone()
+		guild.Emojis = append(guild.Emojis, *emoji)
+	}
+
+	guild.Features = append(guild.Features, g.Features...)
+
+	return guild
+}
+
+// Clone returns a clone of this Role.
+func (r *Role) Clone() *Role {
+	if r == nil {
+		return nil
+	}
+
+	return &Role{
+		ID:          r.ID,
+		Name:        r.Name,
+		Color:       r.Color,
+		Hoist:       r.Hoist,
+		Position:    r.Position,
+		Permissions: r.Permissions,
+		Managed:     r.Managed,
+		Mentionable: r.Mentionable,
+	}
+}
+
+// Clone returns a clone of this Emoji.
+func (e *Emoji) Clone() *Emoji {
+	if e == nil {
+		return nil
+	}
+
+	emoji := &Emoji{
+		ID:            e.ID,
+		Name:          e.Name,
+		RequireColons: e.RequireColons,
+		Managed:       e.Managed,
+		Animated:      e.Animated,
+	}
+
+	for i := 0; i < len(e.Roles); i++ {
+		role := e.Roles[i].Clone()
+		emoji.Roles = append(emoji.Roles, *role)
+	}
+
+	emoji.User = e.User.Clone()
+
+	return emoji
+}
+
+// Clone returns a clone of this VoiceState.
+func (v *VoiceState) Clone() *VoiceState {
+	if v == nil {
+		return nil
+	}
+
+	return &VoiceState{
+		GuildID:   v.GuildID,
+		ChannelID: v.ChannelID,
+		UserID:    v.UserID,
+		SessionID: v.SessionID,
+		Deaf:      v.Deaf,
+		Mute:      v.Mute,
+		SelfDeaf:  v.SelfDeaf,
+		SelfMute:  v.SelfMute,
+		Suppress:  v.Suppress,
+	}
+}
+
+// Clone returns a clone of this GuildMember.
+func (m *GuildMember) Clone() *GuildMember {
+	if m == nil {
+		return nil
+	}
+
+	return &GuildMember{
+		User:     m.User,
+		Nick:     m.Nick,
+		Roles:    m.Roles,
+		JoinedAt: m.JoinedAt,
+		Deaf:     m.Deaf,
+		Mute:     m.Mute,
+	}
+}
+
+// Clone returns a clone of this Channel.
+func (c *Channel) Clone() *Channel {
+	if c == nil {
+		return nil
+	}
+
+	channel := &Channel{
+		ID:               c.ID,
+		Type:             c.Type,
+		GuildID:          c.GuildID,
+		Position:         c.Position,
+		Name:             c.Name,
+		Topic:            c.Topic,
+		NSFW:             c.NSFW,
+		LastMessageID:    c.LastMessageID,
+		Bitrate:          c.Bitrate,
+		UserLimit:        c.UserLimit,
+		Icon:             c.Icon,
+		OwnerID:          c.OwnerID,
+		ApplicationID:    c.ApplicationID,
+		ParentID:         c.ParentID,
+		LastPinTimestamp: c.LastPinTimestamp,
+	}
+
+	for i := 0; i < len(c.PermissionOverwrites); i++ {
+		overwrite := c.PermissionOverwrites[i].Clone()
+		channel.PermissionOverwrites = append(channel.PermissionOverwrites, *overwrite)
+	}
+
+	for i := 0; i < len(c.Recipients); i++ {
+		recipient := c.Recipients[i].Clone()
+		channel.Recipients = append(channel.Recipients, *recipient)
+	}
+
+	return channel
+}
+
+// Clone returns a clone of this Presence.
+func (p *Presence) Clone() *Presence {
+	if p == nil {
+		return nil
+	}
+
+	presence := &Presence{
+		User:    p.User,
+		Game:    p.Game,
+		GuildID: p.GuildID,
+		Status:  p.Status,
+	}
+
+	presence.Roles = append(presence.Roles, p.Roles...)
+
+	return presence
+}
+
+// Clone returns a clone of this UnavailableGuild.
+func (g *UnavailableGuild) Clone() *UnavailableGuild {
+	if g == nil {
+		return nil
+	}
+
+	return &UnavailableGuild{
+		ID:          g.ID,
+		Unavailable: g.Unavailable,
+	}
+}

--- a/debug/http.go
+++ b/debug/http.go
@@ -19,9 +19,6 @@ func NewHTTP(state *discord.State) {
 }
 
 func (d *httpDebugger) index(w http.ResponseWriter, r *http.Request) {
-	d.state.RLock()
-	defer d.state.RUnlock()
-
 	state := struct {
 		UsersCount             int `json:"users_count"`
 		GuildsCount            int `json:"guilds_count"`
@@ -49,9 +46,6 @@ func (d *httpDebugger) index(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *httpDebugger) all(w http.ResponseWriter, r *http.Request) {
-	d.state.RLock()
-	defer d.state.RUnlock()
-
 	state := struct {
 		CurrentUser       *discord.User                        `json:"current_user"`
 		Users             map[string]*discord.User             `json:"users"`

--- a/doc.go
+++ b/doc.go
@@ -68,14 +68,7 @@ is constantly updated so it always have the newest data available.
 This session state acts as a cache to avoid making requests over the HTTP API
 each time. If you need to get information about the current user :
 
-	c.State.RLock()
 	user := c.State.CurrentUser()
-	// Do stuff with user
-	c.State.RUnlock()
-
-Note that for this state to be thread safe and to continue to be updated while
-being used, it needs to be locked/unlocked (with its RLock and RUnlock
-methods) when accessed.
 
 Because this state might become memory hungry for bots that are in a very
 large number of servers, it can be disabled with the WithStateTracking option

--- a/permission/permission.go
+++ b/permission/permission.go
@@ -43,6 +43,20 @@ type Overwrite struct {
 	Deny  int
 }
 
+// Clone returns a clone of this Overwrite.
+func (o *Overwrite) Clone() *Overwrite {
+	if o == nil {
+		return nil
+	}
+
+	return &Overwrite{
+		ID:    o.ID,
+		Type:  o.Type,
+		Allow: o.Allow,
+		Deny:  o.Deny,
+	}
+}
+
 // Contains returns whether the given permission is set in permissions.
 func Contains(permissions, permission int) bool {
 	return permissions&permission == permission


### PR DESCRIPTION
This PR removes the need to lock/unlock the State each time a call to one of its methods is performed. Instead, they will return snapshots (i.e.: clones - or deep copies of those objects) that are safe to be used and modified.