### PR TITLE
Allow the AFK channel to be disabled and add the AFKTimeout type for WithAFKTimeout

### DIFF
--- a/guild/settings.go
+++ b/guild/settings.go
@@ -12,8 +12,8 @@ type Settings struct {
 	VerificationLevel           *optional.Int    `json:"verification_level,omitempty"`
 	DefaultMessageNotifications *optional.Int    `json:"default_message_notifications,omitempty"`
 	ExplicitContentFilter       *optional.Int    `json:"explicit_content_filter,omitempty"`
-	AfkChannelID                *optional.String `json:"afk_channel_id,omitempty"`
-	AfkTimeout                  *optional.Int    `json:"afk_timeout,omitempty"`
+	AFKChannelID                *optional.String `json:"afk_channel_id,omitempty"`
+	AFKTimeout                  *optional.Int    `json:"afk_timeout,omitempty"`
 	Icon                        *optional.String `json:"icon,omitempty"`
 	OwnerID                     *optional.String `json:"owner_id,omitempty"`
 	Splash                      *optional.String `json:"splash,omitempty"`
@@ -141,17 +141,22 @@ func WithExplicitContentFilter(lvl ExplicitContentFilter) Setting {
 	}
 }
 
-// WithAfkChannel sets the AFK channel ID of a guild.
-func WithAfkChannel(id string) Setting {
+// WithAFKChannel sets the AFK channel ID of a guild.
+// An empty id will disable the AFK channel.
+func WithAFKChannel(id string) Setting {
 	return func(s *Settings) {
-		s.AfkChannelID = optional.NewString(id)
+		if id == "" {
+			s.AFKChannelID = optional.NewNilString()
+		} else {
+			s.AFKChannelID = optional.NewString(id)
+		}
 	}
 }
 
-// WithAfkTimeout sets the AFK timeout of a guild.
-func WithAfkTimeout(sec int) Setting {
+// WithAFKTimeout sets the AFK timeout of a guild.
+func WithAFKTimeout(sec int) Setting {
 	return func(s *Settings) {
-		s.AfkTimeout = optional.NewInt(sec)
+		s.AFKTimeout = optional.NewInt(sec)
 	}
 }
 

--- a/guild/settings.go
+++ b/guild/settings.go
@@ -153,10 +153,21 @@ func WithAFKChannel(id string) Setting {
 	}
 }
 
+// AFKTimeout is the set of allowed values for AFK timeouts.
+type AFKTimeout int
+
+const (
+	AFKTimeoutOneMinute      AFKTimeout = 60
+	AFKTimeoutFiveMinutes    AFKTimeout = 300
+	AFKTimeoutFifteenMinutes AFKTimeout = 900
+	AFKTimeoutThirtyMinutes  AFKTimeout = 1800
+	AFKTimeoutOneHour        AFKTimeout = 3600
+)
+
 // WithAFKTimeout sets the AFK timeout of a guild.
-func WithAFKTimeout(sec int) Setting {
+func WithAFKTimeout(t AFKTimeout) Setting {
 	return func(s *Settings) {
-		s.AFKTimeout = optional.NewInt(sec)
+		s.AFKTimeout = optional.NewInt(int(t))
 	}
 }
 


### PR DESCRIPTION
### Description

This PR fixes a bug which prevented a user to disabled the AFK channel of a guild. To do so, simply use the `WithAFKChannel` option with an empty id.

Also, this PR renames `Afk...` occurrences to the more idiomatic `AFK...`. 

Finally, this PR introduces a new AFKTimout type that contains only the valid values that can be passed to WithAFKTimeout.