### PR TITLE
Send now returns an error if no content, embed nor file is provided

### DIFF
--- a/channel_message.go
+++ b/channel_message.go
@@ -247,6 +247,10 @@ func (r *ChannelResource) Send(ctx context.Context, opts ...MessageOption) (*Mes
 		opt(&msg)
 	}
 
+	if msg.Content == "" && msg.Embed == nil && len(msg.files) == 0 {
+		return nil, ErrInvalidSend
+	}
+
 	return r.client.sendMessage(ctx, r.channelID, &msg)
 }
 

--- a/error.go
+++ b/error.go
@@ -13,8 +13,8 @@ import (
 var (
 	// ErrGatewayNotConnected is returned when the client is not connected to the Gateway.
 	ErrGatewayNotConnected = errors.New("gateway is not connected")
-	// ErrNoFileProvided is returned by SendFiles when no files are provided.
-	ErrNoFileProvided = errors.New("no file provided")
+	// ErrInvalidSend is returned by Send when no files are provided.
+	ErrInvalidSend = errors.New("no content, embed nor file provided")
 )
 
 // APIError is a generic error returned by the Discord HTTP API.


### PR DESCRIPTION
### Description

`Send` now returns `ErrInvalidSend` when called without at least one of the following options:
- `WithContent`
- `WithEmbed`
- `WithFiles`