### PR TITLE
NewInvite now takes settings like other similar methods

### DIFF
--- a/harmony_test.go
+++ b/harmony_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/skwair/harmony"
 	"github.com/skwair/harmony/channel"
+	"github.com/skwair/harmony/invite"
 	"github.com/skwair/harmony/permission"
 	"github.com/skwair/harmony/role"
 )
@@ -66,6 +67,21 @@ func TestHarmony(t *testing.T) {
 		txtCh, err = client.Guild(guildID).NewChannel(context.TODO(), settings)
 		if err != nil {
 			t.Fatalf("could not create text channel: %v", err)
+		}
+	})
+
+	t.Run("create a channel invite", func(t *testing.T) {
+		settings := invite.NewSettings(
+			invite.WithMaxUses(1),
+		)
+
+		i, err := client.Channel(txtCh.ID).NewInvite(context.TODO(), settings)
+		if err != nil {
+			t.Fatalf("could not create new invitation: %v", err)
+		}
+
+		if i.MaxUses != 1 {
+			t.Fatalf("expected to new invite to have %d max uses; got %d", 1, i.MaxUses)
 		}
 	})
 

--- a/invite/settings.go
+++ b/invite/settings.go
@@ -1,0 +1,54 @@
+package invite
+
+import "github.com/skwair/harmony/optional"
+
+// Settings describes how to modify a guild role. All fields are optional.
+type Settings struct {
+	MaxAge    *optional.Int  `json:"max_age,omitempty"`
+	MaxUses   *optional.Int  `json:"max_uses,omitempty"`
+	Temporary *optional.Bool `json:"temporary,omitempty"`
+	Unique    *optional.Bool `json:"unique,omitempty"`
+}
+
+// Setting is a function that configures a guild role.
+type Setting func(*Settings)
+
+// NewSettings returns new Settings to modify a a guild role.
+func NewSettings(opts ...Setting) *Settings {
+	s := &Settings{}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// WithMaxAge sets the maximum age (in seconds) of a channel invite.
+func WithMaxAge(max int) Setting {
+	return func(s *Settings) {
+		s.MaxAge = optional.NewInt(max)
+	}
+}
+
+// WithMaxUses sets maximum number of times this invite can be used.
+func WithMaxUses(max int) Setting {
+	return func(s *Settings) {
+		s.MaxUses = optional.NewInt(max)
+	}
+}
+
+// WithTemporary sets whether this invite only grants temporary membership.
+func WithTemporary(yes bool) Setting {
+	return func(s *Settings) {
+		s.Temporary = optional.NewBool(yes)
+	}
+}
+
+// WithUnique sets whether this invite is unique. If set to true, don't try to
+// reuse a similar invite (useful for creating many unique one time use invites).
+func WithUnique(yes bool) Setting {
+	return func(s *Settings) {
+		s.Unique = optional.NewBool(yes)
+	}
+}

--- a/role/settings.go
+++ b/role/settings.go
@@ -35,14 +35,14 @@ func WithName(name string) Setting {
 // WithPermissions sets the permissions of guild a role.
 func WithPermissions(perm int) Setting {
 	return func(s *Settings) {
-		s.Permissions = optional.NewInt(int(perm))
+		s.Permissions = optional.NewInt(perm)
 	}
 }
 
 // WithColor sets the color of guild a role. It accepts hexadecimal value.
 func WithColor(hexCode int) Setting {
 	return func(s *Settings) {
-		s.Color = optional.NewInt(int(hexCode))
+		s.Color = optional.NewInt(hexCode)
 	}
 }
 


### PR DESCRIPTION
### Description

`NewInvite` now takes a `invite.Settings` struct instead of four individual parameters (not counting the context).

Before:

```go
i, err := c.Channel("channel-id").NewInvite(context.TODO(), 0, 1, false, true)
if err != nil {
	fmt.Println(err)
}
```

Now:

```go
settings := invite.NewSettings(
	invite.WithMaxUses(1),
	invite.WithUnique(true),
)

i, err := c.Channel("channel-id").NewInvite(context.TODO(), settings)
if err != nil {
	fmt.Println(err)
}
```