### PR TITLE
Allow customization of the User-Agent header and improve doc

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,8 +21,8 @@ var (
 	// ErrNoTokenProvided is returned by NewClient when neither a user token nor a bot token is provided.
 	ErrNoTokenProvided = errors.New("no token provided, use WithToken or WithBotToken when creating a new client")
 
-	// defaultErrorHandler is the default handle that is called when an error occurs when connected to the Gateway.
-	defaultErrorHandler = func(err error) { log.Println("gateway client error:", err) }
+	// DefaultErrorHandler is the default handle that is called when an error occurs when connected to the Gateway.
+	DefaultErrorHandler = func(err error) { log.Println("gateway client error:", err) }
 
 	// defaultBackoff is the backoff strategy used by default when trying to reconnect to the Gateway.
 	defaultBackoff = backoff{
@@ -40,6 +40,11 @@ type Client struct {
 	// General lock for long operations that should
 	// not happen concurrently like Connect or Disconnect.
 	mu sync.Mutex
+
+	// This is the name of the bot, used to set the
+	// User-Agent when sending HTTP request.
+	// It defaults to "Harmony".
+	name string
 
 	token string
 	// Whether this is a regular user or a bot user.
@@ -117,10 +122,11 @@ type Client struct {
 // It is meant to be long lived and shared across your application.
 func NewClient(opts ...ClientOption) (*Client, error) {
 	c := &Client{
+		name:              "Harmony",
 		baseURL:           defaultBaseURL,
 		client:            http.DefaultClient,
 		largeThreshold:    defaultLargeThreshold,
-		errorHandler:      defaultErrorHandler,
+		errorHandler:      DefaultErrorHandler,
 		handlers:          make(map[string]handler),
 		limiter:           rate.NewLimiter(),
 		backoff:           defaultBackoff,

--- a/client_options.go
+++ b/client_options.go
@@ -9,6 +9,15 @@ import (
 // It is used in NewClient.
 type ClientOption func(*Client)
 
+// WithName sets the name of the client. It will be used to
+// set the User-Agent of HTTP requests sent by the Client.
+// Defaults to "Harmony".
+func WithName(n string) ClientOption {
+	return func(c *Client) {
+		c.name = n
+	}
+}
+
 // WithToken sets the token for a user client. Every call to
 // NewClient must include this option or the WithBotToken
 // option if the client is a bot instead of a regular user.
@@ -30,6 +39,7 @@ func WithBotToken(token string) ClientOption {
 
 // WithHTTPClient can be used to specify the http.Client to use when making
 // HTTP requests to the Discord HTTP API.
+// Defaults to http.DefaultClient.
 func WithHTTPClient(client *http.Client) ClientOption {
 	return func(c *Client) {
 		c.client = client
@@ -38,6 +48,7 @@ func WithHTTPClient(client *http.Client) ClientOption {
 
 // WithBaseURL can be used to change de base URL of the API.
 // This is used for testing.
+// Deprecated.
 func WithBaseURL(url string) ClientOption {
 	return func(c *Client) {
 		c.baseURL = url
@@ -47,6 +58,7 @@ func WithBaseURL(url string) ClientOption {
 // WithErrorHandler allows you to specify a custom error handler function
 // that will be called whenever an error occurs while the connection
 // to the Gateway is up.
+// Defaults to DefaultErrorHandler.
 func WithErrorHandler(h func(error)) ClientOption {
 	return func(c *Client) {
 		c.errorHandler = h
@@ -55,6 +67,7 @@ func WithErrorHandler(h func(error)) ClientOption {
 
 // WithSharding allows you to specify a sharding configuration when connecting to the Gateway.
 // See https://discordapp.com/developers/docs/topics/gateway#sharding for more details.
+// Default to nothing, sharding is not enabled.
 func WithSharding(current, total int) ClientOption {
 	return func(c *Client) {
 		c.shard[0] = current
@@ -64,6 +77,7 @@ func WithSharding(current, total int) ClientOption {
 
 // WithStateTracking allows you to specify whether the client is tracking the state of
 // the current connection or not.
+// Defaults to true.
 func WithStateTracking(y bool) ClientOption {
 	return func(c *Client) {
 		c.withStateTracking = y
@@ -73,6 +87,7 @@ func WithStateTracking(y bool) ClientOption {
 // WithLargeThreshold allows you to set the large threshold when connecting to the Gateway.
 // This threshold will dictate the number of offline guild members are returned with a guild.
 // See: https://discordapp.com/developers/docs/topics/gateway#request-guild-members for more details.
+// Defaults to 250.
 func WithLargeThreshold(t int) ClientOption {
 	return func(c *Client) {
 		if t > 250 {
@@ -88,6 +103,7 @@ func WithLargeThreshold(t int) ClientOption {
 // WithBackoffStrategy allows you to customize the backoff strategy used when trying
 // to reconnect to the Discord Gateway after an error occurred (such as a network
 // failure).
+// Defaults to 1s (baseDelay), 120s (maxDelay), 1.6 (factor), 0.2 (jitter).
 func WithBackoffStrategy(baseDelay, maxDelay time.Duration, factor, jitter float64) ClientOption {
 	return func(c *Client) {
 		c.backoff.baseDelay = baseDelay

--- a/request.go
+++ b/request.go
@@ -11,7 +11,8 @@ import (
 	"github.com/skwair/harmony/internal/endpoint"
 )
 
-// doReq calls doReqWithHeader with the Content-Type to "application/json" if the body is not nil.
+// doReq calls doReqWithHeader with the Content-Type header set to "application/json"
+// if the provided body is not nil.
 // If you need more control over headers you send, use doReqWithHeader directly.
 func (c *Client) doReq(ctx context.Context, e *endpoint.Endpoint, body []byte) (*http.Response, error) {
 	h := http.Header{}
@@ -22,10 +23,10 @@ func (c *Client) doReq(ctx context.Context, e *endpoint.Endpoint, body []byte) (
 	return c.doReqWithHeader(ctx, e, body, h)
 }
 
-// doReqWithHeader sends an HTTP request and returns the response given
-// an endpoint an optional body that can be set to nil and some headers. It adds the
-// required Authorization and User-Agent header.
-// It also takes care of rate limiting, using the client's built in rate limiter.
+// doReqWithHeader sends an HTTP request and returns the response given an endpoint
+// an optional body and some headers. It adds the required Authorization header and
+// also sets the User-Agent.
+// It takes care of rate limiting, using the client's built in rate limiter.
 func (c *Client) doReqWithHeader(ctx context.Context, e *endpoint.Endpoint, body []byte, h http.Header) (*http.Response, error) {
 	req, err := http.NewRequest(e.Method, c.baseURL+e.URL, bytes.NewBuffer(body))
 	if err != nil {
@@ -42,9 +43,7 @@ func (c *Client) doReqWithHeader(ctx context.Context, e *endpoint.Endpoint, body
 		}
 	}
 	req.Header.Set("Authorization", c.token)
-	// NOTE: maybe allow the "Harmony" to be configurable when creating a client.
-	// If we allow it, how would doReqNoAuthWithHeader get it ?
-	ua := fmt.Sprintf("%s (github.com/skwair/harmony, %s)", "Harmony", version)
+	ua := fmt.Sprintf("%s (github.com/skwair/harmony, %s)", c.name, version)
 	req.Header.Set("User-Agent", ua)
 
 	c.limiter.Wait(e.Key)


### PR DESCRIPTION
### Description

This PR adds the possibility to customize the name of the application sent in the `User-Agent` header when the `Client` makes HTTP requests:

```go
harmony.NewClient(harmony.WithBotToken("your.bot.token"), harmony.WithName("yourAppName"))
```