### PR TITLE
Remove self bot support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ install:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.13.1
 script:
   - golangci-lint run
+  - _scripts/build_examples.sh
   - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ install:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.13.1
 script:
   - golangci-lint run
-  - _scripts/build_examples.sh
+  - bash _scripts/build_examples.sh
   - go test -v -race ./...

--- a/_scripts/build_example.sh
+++ b/_scripts/build_example.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+
+for f in examples/*; do
+	if [[ -d $f ]]; then
+		go build ./$f;
+	fi;
+done

--- a/_scripts/build_examples.sh
+++ b/_scripts/build_examples.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 
 for f in examples/*; do
-	if [[ -d $f ]]; then
-		go build ./$f;
+	if [[ -d ${f} ]]; then
+		go build ./${f};
 	fi;
 done

--- a/client.go
+++ b/client.go
@@ -117,7 +117,7 @@ type Client struct {
 func NewClient(token string, opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		name:              "Harmony",
-		token:             token,
+		token:             "Bot " + token,
 		baseURL:           defaultBaseURL,
 		client:            http.DefaultClient,
 		largeThreshold:    defaultLargeThreshold,

--- a/client_options.go
+++ b/client_options.go
@@ -18,25 +18,6 @@ func WithName(n string) ClientOption {
 	}
 }
 
-// WithToken sets the token for a user client. Every call to
-// NewClient must include this option or the WithBotToken
-// option if the client is a bot instead of a regular user.
-func WithToken(token string) ClientOption {
-	return func(c *Client) {
-		c.token = token
-	}
-}
-
-// WithBotToken sets the token for a bot client. Every call to
-// NewClient must include this option or the WithToken option
-// if the client is a regular user instead of a bot.
-func WithBotToken(token string) ClientOption {
-	return func(c *Client) {
-		c.token = "Bot " + token
-		c.bot = true
-	}
-}
-
 // WithHTTPClient can be used to specify the http.Client to use when making
 // HTTP requests to the Discord HTTP API.
 // Defaults to http.DefaultClient.

--- a/examples/01.pingpong/main.go
+++ b/examples/01.pingpong/main.go
@@ -23,8 +23,8 @@ type bot struct {
 
 func main() {
 	// Fetch the bot token from env.
-	botToken := os.Getenv("BOT_TOKEN")
-	if botToken == "" {
+	token := os.Getenv("BOT_TOKEN")
+	if token == "" {
 		// Not using log.Fatal() or anything that calls os.Exit()
 		// because defers are not run, thus we won't disconnect
 		// properly from the Gateway.
@@ -33,9 +33,9 @@ func main() {
 	}
 
 	// Create a harmony client with a bot token.
-	// Using WithBotToken will automatically prepend your bot token
-	// with "Bot ", which is a requirement by Discord for bot users.
-	c, err := harmony.NewClient(harmony.WithBotToken(botToken))
+	// NewClient automatically prepends your bot token with "Bot ",
+	// which is a requirement by Discord for bot users.
+	c, err := harmony.NewClient(token)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v", err)
 		return

--- a/examples/02.embed/main.go
+++ b/examples/02.embed/main.go
@@ -20,13 +20,13 @@ type bot struct {
 }
 
 func main() {
-	botToken := os.Getenv("BOT_TOKEN")
-	if botToken == "" {
+	token := os.Getenv("BOT_TOKEN")
+	if token == "" {
 		fmt.Fprint(os.Stderr, "Environment variable BOT_TOKEN must be set.")
 		return
 	}
 
-	c, err := harmony.NewClient(harmony.WithBotToken(botToken))
+	c, err := harmony.NewClient(token)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v", err)
 		return

--- a/examples/03.files/main.go
+++ b/examples/03.files/main.go
@@ -18,13 +18,13 @@ type bot struct {
 }
 
 func main() {
-	botToken := os.Getenv("BOT_TOKEN")
-	if botToken == "" {
+	token := os.Getenv("BOT_TOKEN")
+	if token == "" {
 		fmt.Fprint(os.Stderr, "Environment variable BOT_TOKEN must be set.")
 		return
 	}
 
-	c, err := harmony.NewClient(harmony.WithBotToken(botToken))
+	c, err := harmony.NewClient(token)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v", err)
 		return

--- a/harmony_test.go
+++ b/harmony_test.go
@@ -24,7 +24,7 @@ func TestHarmony(t *testing.T) {
 		t.Fatal("environment variable HARMONY_TEST_GUILD_ID not set")
 	}
 
-	client, err := harmony.NewClient(harmony.WithBotToken(token))
+	client, err := harmony.NewClient(token)
 	if err != nil {
 		t.Fatalf("could not create harmony client: %v", err)
 	}


### PR DESCRIPTION
### Description

This PR removes support for automated normal user accounts (generally called "self-bots") as this is a violation of Discord's TOS.

This change makes `WithToken` and `WithBotToken` useless, the bot token is now directly passed as a parameter of `NewClient`.

It also updates the CI so it build examples to ensure they compile.