### PR TITLE
Add audit log reason support

### DIFF
--- a/audit_log.go
+++ b/audit_log.go
@@ -1,0 +1,15 @@
+package harmony
+
+import "net/http"
+
+const auditLogReasonHeader = "X-Audit-Log-Reason"
+
+func reasonHeader(r string) http.Header {
+	h := http.Header{}
+
+	if r != "" {
+		h.Set(auditLogReasonHeader, r)
+	}
+
+	return h
+}

--- a/channel.go
+++ b/channel.go
@@ -87,7 +87,7 @@ func (r *ChannelResource) ModifyWithReason(ctx context.Context, settings *channe
 	}
 
 	e := endpoint.ModifyChannel(r.channelID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (r *ChannelResource) UpdatePermissionsWithReason(ctx context.Context, targe
 	}
 
 	e := endpoint.EditChannelPermissions(r.channelID, targetID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func (r *ChannelResource) NewInviteWithReason(ctx context.Context, settings *inv
 	}
 
 	e := endpoint.CreateChannelInvite(r.channelID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +332,7 @@ func (r *ChannelResource) NewWebhookWithReason(ctx context.Context, name, avatar
 	}
 
 	e := endpoint.CreateWebhook(r.channelID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}

--- a/channel.go
+++ b/channel.go
@@ -109,7 +109,7 @@ func (r *ChannelResource) Delete(ctx context.Context) (*Channel, error) {
 	return r.DeleteWithReason(ctx, "")
 }
 
-// Delete deletes the channel, or closes the private message. Requires the 'MANAGE_CHANNELS'
+// DeleteWithReason deletes the channel, or closes the private message. Requires the 'MANAGE_CHANNELS'
 // permission for the guild. Deleting a category does not delete its child channels; they will
 // have their parent_id removed and a Channel Update Gateway event will fire for each of them.
 // Returns the deleted channel on success. Fires a Channel Delete Gateway event.
@@ -138,8 +138,8 @@ func (r *ChannelResource) UpdatePermissions(ctx context.Context, targetID string
 	return r.UpdatePermissionsWithReason(ctx, targetID, allow, deny, typ, "")
 }
 
-// UpdatePermissions updates the channel permission overwrites for a user or role in the channel.
-// typ is "member" if targetID is a user or "role" if it is a role.
+// UpdatePermissionsWithReason updates the channel permission overwrites for a user or
+// role in the channel. typ is "member" if targetID is a user or "role" if it is a role.
 // If the channel permission overwrites do not not exist, they are created.
 // Only usable for guild channels. Requires the 'MANAGE_ROLES' permission.
 // The given reason will be set in the audit log entry for this action.
@@ -179,8 +179,9 @@ func (r *ChannelResource) DeletePermission(ctx context.Context, channelID, targe
 	return r.DeletePermissionWithReason(ctx, channelID, targetID, "")
 }
 
-// DeletePermission deletes the channel permission overwrite for a user or role in a
-// channel. Only usable for guild channels. Requires the 'MANAGE_ROLES' permission.
+// DeletePermissionWithReason deletes the channel permission overwrite for a user or
+// role in a channel. Only usable for guild channels. Requires the 'MANAGE_ROLES'
+// permission.
 // The given reason will be set in the audit log entry for this action.
 func (r *ChannelResource) DeletePermissionWithReason(ctx context.Context, channelID, targetID, reason string) error {
 	e := endpoint.DeleteChannelPermission(channelID, targetID)
@@ -222,8 +223,8 @@ func (r *ChannelResource) NewInvite(ctx context.Context, settings *invite.Settin
 	return r.NewInviteWithReason(ctx, settings, "")
 }
 
-// NewInvite creates a new invite for the channel. Only usable for guild channels.
-// Requires the CREATE_INSTANT_INVITE permission.
+// NewInviteWithReason creates a new invite for the channel. Only usable
+// for guild channels. Requires the CREATE_INSTANT_INVITE permission.
 // The given reason will be set in the audit log entry for this action.
 func (r *ChannelResource) NewInviteWithReason(ctx context.Context, settings *invite.Settings, reason string) (*Invite, error) {
 	b, err := json.Marshal(settings)
@@ -311,7 +312,7 @@ func (r *ChannelResource) NewWebhook(ctx context.Context, name, avatar string) (
 	return r.NewWebhookWithReason(ctx, name, avatar, "")
 }
 
-// NewWebhook creates a new webhook for the channel. Requires the 'MANAGE_WEBHOOKS'
+// NewWebhookWithReason creates a new webhook for the channel. Requires the 'MANAGE_WEBHOOKS'
 // permission.
 // name must contain between 2 and 32 characters. avatar is an avatar data string,
 // see https://discordapp.com/developers/docs/resources/user#avatar-data for more info.

--- a/channel_message.go
+++ b/channel_message.go
@@ -157,7 +157,7 @@ func (r *ChannelResource) DeleteMessage(ctx context.Context, messageID string) e
 	return r.DeleteMessageWithReason(ctx, messageID, "")
 }
 
-// DeleteMessage deletes a message. If operating on a guild channel and trying to delete a
+// DeleteMessageWithReason deletes a message. If operating on a guild channel and trying to delete a
 // message that was not sent by the current user, this endpoint requires the 'MANAGE_MESSAGES'
 // permission. Fires a Message Delete Gateway event.
 // The given reason will be set in the audit log entry for this action.

--- a/channel_message.go
+++ b/channel_message.go
@@ -152,12 +152,18 @@ func (r *ChannelResource) Message(ctx context.Context, id string) (*Message, err
 	return &msg, nil
 }
 
+// DeleteMessage is like DeleteMessageWithReason but with no particular reason.
+func (r *ChannelResource) DeleteMessage(ctx context.Context, messageID string) error {
+	return r.DeleteMessageWithReason(ctx, messageID, "")
+}
+
 // DeleteMessage deletes a message. If operating on a guild channel and trying to delete a
 // message that was not sent by the current user, this endpoint requires the 'MANAGE_MESSAGES'
 // permission. Fires a Message Delete Gateway event.
-func (r *ChannelResource) DeleteMessage(ctx context.Context, messageID string) error {
+// The given reason will be set in the audit log entry for this action.
+func (r *ChannelResource) DeleteMessageWithReason(ctx context.Context, messageID, reason string) error {
 	e := endpoint.DeleteMessage(r.channelID, messageID)
-	resp, err := r.client.doReq(ctx, e, nil)
+	resp, err := r.client.doReqWithHeader(ctx, e, nil, reasonHeader(reason))
 	if err != nil {
 		return err
 	}

--- a/examples/01.pingpong/main.go
+++ b/examples/01.pingpong/main.go
@@ -73,32 +73,9 @@ func (b *bot) onNewMessage(m *harmony.Message) {
 	// If the new message's content is "ping",
 	// Reply with "pong", logging any error
 	// that occurs.
-	msg := withReplier(m, b.client)
-
-	if msg.Content == "ping" {
-		if _, err := msg.Reply(context.Background(), harmony.WithContent("pong")); err != nil {
+	if m.Content == "ping" {
+		if _, err := b.client.Channel(m.ChannelID).SendMessage(context.Background(), "pong"); err != nil {
 			log.Println(err)
 		}
-		// if _, err := b.client.Channel(msg.ChannelID).SendMessage(context.Background(), "pong"); err != nil {
-		// 	log.Println(err)
-		// }
 	}
-}
-
-type message struct {
-	*harmony.Message
-	replyer
-}
-
-type replyer struct {
-	client    *harmony.Client
-	channelID string
-}
-
-func withReplier(msg *harmony.Message, client *harmony.Client) *message {
-	return &message{msg, replyer{client: client, channelID: msg.ChannelID}}
-}
-
-func (r *replyer) Reply(ctx context.Context, opts ...harmony.MessageOption) (*harmony.Message, error) {
-	return r.client.Channel(r.channelID).Send(ctx, opts...)
 }

--- a/guild.go
+++ b/guild.go
@@ -336,7 +336,7 @@ func (r *GuildResource) BeginPrune(ctx context.Context, days int, computePruneCo
 	return r.BeginPruneWithReason(ctx, days, computePruneCount, "")
 }
 
-// BeginPrune begins a prune operation. Requires the 'KICK_MEMBERS' permission.
+// BeginPruneWithReason begins a prune operation. Requires the 'KICK_MEMBERS' permission.
 // Returns the number of members that were removed in the prune operation if
 // computePruneCount is set to true (not recommended for large guilds).
 // Fires multiple Guild Member Remove Gateway events.

--- a/guild.go
+++ b/guild.go
@@ -141,16 +141,22 @@ func (r *GuildResource) Get(ctx context.Context) (*Guild, error) {
 	return &g, nil
 }
 
-// Modify modifies the guild's settings. Requires the 'MANAGE_GUILD' permission.
-// Returns the updated guild on success. Fires a Guild Update Gateway event.
+// Modify is like ModifyWithReason but with no particular reason.
 func (r *GuildResource) Modify(ctx context.Context, settings *guild.Settings) (*Guild, error) {
+	return r.ModifyWithReason(ctx, settings, "")
+}
+
+// ModifyWithReason modifies the guild's settings. Requires the 'MANAGE_GUILD' permission.
+// Returns the updated guild on success. Fires a Guild Update Gateway event.
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) ModifyWithReason(ctx context.Context, settings *guild.Settings, reason string) (*Guild, error) {
 	b, err := json.Marshal(settings)
 	if err != nil {
 		return nil, err
 	}
 
 	e := endpoint.ModifyGuild(r.guildID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -203,15 +209,22 @@ func (r *GuildResource) Channels(ctx context.Context) ([]Channel, error) {
 	return channels, nil
 }
 
-// NewChannel creates a new channel in the guild.
+// NewChannel is like NewChannelWithReason but with no particular reason.
 func (r *GuildResource) NewChannel(ctx context.Context, settings *channel.Settings) (*Channel, error) {
+	return r.NewChannelWithReason(ctx, settings, "")
+}
+
+// NewChannelWithReason creates a new channel in the guild. Requires the MANAGE_CHANNELS permission.
+// Fires a Channel Create Gateway event.
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) NewChannelWithReason(ctx context.Context, settings *channel.Settings, reason string) (*Channel, error) {
 	b, err := json.Marshal(settings)
 	if err != nil {
 		return nil, err
 	}
 
 	e := endpoint.CreateGuildChannel(r.guildID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -318,11 +331,17 @@ func (r *GuildResource) PruneCount(ctx context.Context, days int) (int, error) {
 	return st.Pruned, nil
 }
 
+// BeginPrune is like BeginPruneWithReason but with no particular reason.
+func (r *GuildResource) BeginPrune(ctx context.Context, days int, computePruneCount bool) (pruneCount int, err error) {
+	return r.BeginPruneWithReason(ctx, days, computePruneCount, "")
+}
+
 // BeginPrune begins a prune operation. Requires the 'KICK_MEMBERS' permission.
 // Returns the number of members that were removed in the prune operation if
 // computePruneCount is set to true (not recommended for large guilds).
 // Fires multiple Guild Member Remove Gateway events.
-func (r *GuildResource) BeginPrune(ctx context.Context, days int, computePruneCount bool) (pruneCount int, err error) {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) BeginPruneWithReason(ctx context.Context, days int, computePruneCount bool, reason string) (pruneCount int, err error) {
 	if days < 1 {
 		days = 1
 	}
@@ -331,7 +350,7 @@ func (r *GuildResource) BeginPrune(ctx context.Context, days int, computePruneCo
 	q.Set("days", strconv.Itoa(days))
 	q.Set("compute_prune_count", strconv.FormatBool(computePruneCount))
 	e := endpoint.BeginGuildPrune(r.guildID, q.Encode())
-	resp, err := r.client.doReq(ctx, e, nil)
+	resp, err := r.client.doReqWithHeader(ctx, e, nil, reasonHeader(reason))
 	if err != nil {
 		return 0, err
 	}

--- a/guild.go
+++ b/guild.go
@@ -92,7 +92,7 @@ func (c *Client) CreateGuild(ctx context.Context, name string) (*Guild, error) {
 	}
 
 	e := endpoint.CreateGuild()
-	resp, err := c.doReq(ctx, e, b)
+	resp, err := c.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (r *GuildResource) ModifyWithReason(ctx context.Context, settings *guild.Se
 	}
 
 	e := endpoint.ModifyGuild(r.guildID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func (r *GuildResource) NewChannelWithReason(ctx context.Context, settings *chan
 	}
 
 	e := endpoint.CreateGuildChannel(r.guildID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func (r *GuildResource) ModifyChannelPosition(ctx context.Context, pos []Channel
 	}
 
 	e := endpoint.ModifyChannelPositions(r.guildID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return err
 	}
@@ -286,7 +286,7 @@ func (r *GuildResource) ChangeNick(ctx context.Context, name string) (string, er
 	}
 
 	e := endpoint.ModifyCurrentUserNick(r.guildID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return "", err
 	}
@@ -446,7 +446,7 @@ func (r *GuildResource) ModifyEmbed(ctx context.Context, embed *guild.Embed) (*g
 	}
 
 	e := endpoint.ModifyGuildEmbed(r.guildID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return nil, err
 	}

--- a/guild_ban.go
+++ b/guild_ban.go
@@ -70,11 +70,17 @@ func (r *GuildResource) BanWithReason(ctx context.Context, userID string, delMsg
 	return nil
 }
 
+// Unban is like UnbanWithReason but with no particular reason.
+func (r *GuildResource) Unban(ctx context.Context, userID string) error {
+	return r.UnbanWithReason(ctx, userID, "")
+}
+
 // Unban removes the ban for a user. Requires the 'BAN_MEMBERS' permissions.
 // Fires a Guild Ban Remove Gateway event.
-func (r *GuildResource) Unban(ctx context.Context, userID string) error {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) UnbanWithReason(ctx context.Context, userID, reason string) error {
 	e := endpoint.RemoveGuildBan(r.guildID, userID)
-	resp, err := r.client.doReq(ctx, e, nil)
+	resp, err := r.client.doReqWithHeader(ctx, e, nil, reasonHeader(reason))
 	if err != nil {
 		return err
 	}

--- a/guild_emoji.go
+++ b/guild_emoji.go
@@ -85,7 +85,7 @@ func (r *GuildResource) NewEmojiWithReason(ctx context.Context, name, image stri
 	}
 
 	e := endpoint.CreateGuildEmoji(r.guildID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (r *GuildResource) ModifyEmojiWithReason(ctx context.Context, emojiID, name
 	}
 
 	e := endpoint.ModifyGuildEmoji(r.guildID, emojiID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}

--- a/guild_emoji.go
+++ b/guild_emoji.go
@@ -60,10 +60,16 @@ func (r *GuildResource) Emoji(ctx context.Context, emojiID string) (*Emoji, erro
 	return &emoji, nil
 }
 
+// NewEmoji is like NewEmojiWithReason but with no particular reason.
+func (r *GuildResource) NewEmoji(ctx context.Context, name, image string, roles []string) (*Emoji, error) {
+	return r.NewEmojiWithReason(ctx, name, image, roles, "")
+}
+
 // NewEmoji creates a new emoji for the guild. image is the base64 encoded data of a
 // 128*128 image. Requires the 'MANAGE_EMOJIS' permission. Fires a Guild Emojis Update
 // Gateway event.
-func (r *GuildResource) NewEmoji(ctx context.Context, name, image string, roles []string) (*Emoji, error) {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) NewEmojiWithReason(ctx context.Context, name, image string, roles []string, reason string) (*Emoji, error) {
 	st := struct {
 		Name  string   `json:"name"`
 		Image string   `json:"image"`
@@ -79,7 +85,7 @@ func (r *GuildResource) NewEmoji(ctx context.Context, name, image string, roles 
 	}
 
 	e := endpoint.CreateGuildEmoji(r.guildID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -96,9 +102,15 @@ func (r *GuildResource) NewEmoji(ctx context.Context, name, image string, roles 
 	return &emoji, nil
 }
 
+// ModifyEmoji is like ModifyEmojiWithReason but with no particular reason.
+func (r *GuildResource) ModifyEmoji(ctx context.Context, emojiID, name string, roles []string) (*Emoji, error) {
+	return r.ModifyEmojiWithReason(ctx, emojiID, name, roles, "")
+}
+
 // ModifyEmoji modifies the given emoji for the guild. Requires the 'MANAGE_EMOJIS'
 // permission. Fires a Guild Emojis Update Gateway event.
-func (r *GuildResource) ModifyEmoji(ctx context.Context, emojiID, name string, roles []string) (*Emoji, error) {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) ModifyEmojiWithReason(ctx context.Context, emojiID, name string, roles []string, reason string) (*Emoji, error) {
 	st := struct {
 		Name  string   `json:"name"`
 		Roles []string `json:"roles"`
@@ -112,7 +124,7 @@ func (r *GuildResource) ModifyEmoji(ctx context.Context, emojiID, name string, r
 	}
 
 	e := endpoint.ModifyGuildEmoji(r.guildID, emojiID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -129,11 +141,17 @@ func (r *GuildResource) ModifyEmoji(ctx context.Context, emojiID, name string, r
 	return &emoji, nil
 }
 
+// DeleteEmoji is like DeleteEmojiWithReason but with no particular reason.
+func (r *GuildResource) DeleteEmoji(ctx context.Context, emojiID string) error {
+	return r.DeleteEmojiWithReason(ctx, emojiID, "")
+}
+
 // DeleteEmoji deletes the given emoji. Requires the 'MANAGE_EMOJIS' permission.
 // Fires a Guild Emojis Update Gateway event.
-func (r *GuildResource) DeleteEmoji(ctx context.Context, emojiID string) error {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) DeleteEmojiWithReason(ctx context.Context, emojiID, reason string) error {
 	e := endpoint.DeleteGuildEmoji(r.guildID, emojiID)
-	resp, err := r.client.doReq(ctx, e, nil)
+	resp, err := r.client.doReqWithHeader(ctx, e, nil, reasonHeader(reason))
 	if err != nil {
 		return err
 	}

--- a/guild_emoji.go
+++ b/guild_emoji.go
@@ -65,7 +65,7 @@ func (r *GuildResource) NewEmoji(ctx context.Context, name, image string, roles 
 	return r.NewEmojiWithReason(ctx, name, image, roles, "")
 }
 
-// NewEmoji creates a new emoji for the guild. image is the base64 encoded data of a
+// NewEmojiWithReason creates a new emoji for the guild. image is the base64 encoded data of a
 // 128*128 image. Requires the 'MANAGE_EMOJIS' permission. Fires a Guild Emojis Update
 // Gateway event.
 // The given reason will be set in the audit log entry for this action.
@@ -107,8 +107,8 @@ func (r *GuildResource) ModifyEmoji(ctx context.Context, emojiID, name string, r
 	return r.ModifyEmojiWithReason(ctx, emojiID, name, roles, "")
 }
 
-// ModifyEmoji modifies the given emoji for the guild. Requires the 'MANAGE_EMOJIS'
-// permission. Fires a Guild Emojis Update Gateway event.
+// ModifyEmojiWithReason modifies the given emoji for the guild. Requires
+// the 'MANAGE_EMOJIS' permission. Fires a Guild Emojis Update Gateway event.
 // The given reason will be set in the audit log entry for this action.
 func (r *GuildResource) ModifyEmojiWithReason(ctx context.Context, emojiID, name string, roles []string, reason string) (*Emoji, error) {
 	st := struct {
@@ -146,8 +146,8 @@ func (r *GuildResource) DeleteEmoji(ctx context.Context, emojiID string) error {
 	return r.DeleteEmojiWithReason(ctx, emojiID, "")
 }
 
-// DeleteEmoji deletes the given emoji. Requires the 'MANAGE_EMOJIS' permission.
-// Fires a Guild Emojis Update Gateway event.
+// DeleteEmojiWithReason deletes the given emoji. Requires the 'MANAGE_EMOJIS'
+// permission. Fires a Guild Emojis Update Gateway event.
 // The given reason will be set in the audit log entry for this action.
 func (r *GuildResource) DeleteEmojiWithReason(ctx context.Context, emojiID, reason string) error {
 	e := endpoint.DeleteGuildEmoji(r.guildID, emojiID)

--- a/guild_integration.go
+++ b/guild_integration.go
@@ -68,7 +68,7 @@ func (r *GuildResource) AddIntegration(ctx context.Context, id, typ string) erro
 	}
 
 	e := endpoint.CreateGuildIntegration(r.guildID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (r *GuildResource) ModifyIntegration(ctx context.Context, id string, settin
 	}
 
 	e := endpoint.ModifyGuildIntegration(r.guildID, id)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return err
 	}

--- a/guild_member.go
+++ b/guild_member.go
@@ -130,11 +130,17 @@ func (r *GuildResource) AddMember(ctx context.Context, userID, token string, set
 	return &member, nil
 }
 
+// RemoveMember is like RemoveMemberWithReason but with no particular reason.
+func (r *GuildResource) RemoveMember(ctx context.Context, userID string) error {
+	return r.RemoveMemberWithReason(ctx, userID, "")
+}
+
 // RemoveMember removes the given user from the guild. Requires 'KICK_MEMBERS'
 // permission. Fires a Guild Member Remove Gateway event.
-func (r *GuildResource) RemoveMember(ctx context.Context, userID string) error {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) RemoveMemberWithReason(ctx context.Context, userID, reason string) error {
 	e := endpoint.RemoveGuildMember(r.guildID, userID)
-	resp, err := r.client.doReq(ctx, e, nil)
+	resp, err := r.client.doReqWithHeader(ctx, e, nil, reasonHeader(reason))
 	if err != nil {
 		return err
 	}
@@ -146,16 +152,22 @@ func (r *GuildResource) RemoveMember(ctx context.Context, userID string) error {
 	return nil
 }
 
+// ModifyMember is like ModifyMemberWithReason but with no particular reason.
+func (r *GuildResource) ModifyMember(ctx context.Context, userID string, settings *guild.MemberSettings) error {
+	return r.ModifyMemberWithReason(ctx, userID, settings, "")
+}
+
 // ModifyMember modifies attributes of a guild member. Fires a Guild Member
 // Update Gateway event.
-func (r *GuildResource) ModifyMember(ctx context.Context, userID string, settings *guild.MemberSettings) error {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) ModifyMemberWithReason(ctx context.Context, userID string, settings *guild.MemberSettings, reason string) error {
 	b, err := json.Marshal(settings)
 	if err != nil {
 		return err
 	}
 
 	e := endpoint.ModifyGuildMember(r.guildID, userID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
 	if err != nil {
 		return err
 	}

--- a/guild_member.go
+++ b/guild_member.go
@@ -113,7 +113,7 @@ func (r *GuildResource) AddMember(ctx context.Context, userID, token string, set
 	}
 
 	e := endpoint.AddGuildMember(r.guildID, userID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (r *GuildResource) ModifyMemberWithReason(ctx context.Context, userID strin
 	}
 
 	e := endpoint.ModifyGuildMember(r.guildID, userID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return err
 	}

--- a/guild_role.go
+++ b/guild_role.go
@@ -61,7 +61,7 @@ func (r *GuildResource) NewRoleWithReason(ctx context.Context, settings *role.Se
 	}
 
 	e := endpoint.CreateGuildRole(r.guildID)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (r *GuildResource) ModifyRolePositions(ctx context.Context, pos []RolePosit
 	}
 
 	e := endpoint.ModifyGuildRolePositions(r.guildID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (r *GuildResource) ModifyRoleWithReason(ctx context.Context, id string, set
 	}
 
 	e := endpoint.ModifyGuildRole(r.guildID, id)
-	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
+	resp, err := r.client.doReqWithHeader(ctx, e, jsonPayload(b), reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}

--- a/guild_role.go
+++ b/guild_role.go
@@ -46,16 +46,22 @@ func (r *GuildResource) Roles(ctx context.Context) ([]Role, error) {
 	return roles, nil
 }
 
+// NewRole is like NewRoleWithReason but with no particular reason.
+func (r *GuildResource) NewRole(ctx context.Context, settings *role.Settings) (*Role, error) {
+	return r.NewRoleWithReason(ctx, settings, "")
+}
+
 // NewRole creates a new role for the guild. Requires the 'MANAGE_ROLES'
 // permission. Fires a Guild Role Create Gateway event.
-func (r *GuildResource) NewRole(ctx context.Context, settings *role.Settings) (*Role, error) {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) NewRoleWithReason(ctx context.Context, settings *role.Settings, reason string) (*Role, error) {
 	b, err := json.Marshal(settings)
 	if err != nil {
 		return nil, err
 	}
 
 	e := endpoint.CreateGuildRole(r.guildID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -105,16 +111,22 @@ func (r *GuildResource) ModifyRolePositions(ctx context.Context, pos []RolePosit
 	return roles, nil
 }
 
+// ModifyRole is like ModifyRoleWithReason but with no particular reason.
+func (r *GuildResource) ModifyRole(ctx context.Context, id string, settings *role.Settings) (*Role, error) {
+	return r.ModifyRoleWithReason(ctx, id, settings, "")
+}
+
 // ModifyRole modifies a guild role. Requires the 'MANAGE_ROLES' permission.
 // Fires a Guild Role Update Gateway event.
-func (r *GuildResource) ModifyRole(ctx context.Context, id string, settings *role.Settings) (*Role, error) {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) ModifyRoleWithReason(ctx context.Context, id string, settings *role.Settings, reason string) (*Role, error) {
 	b, err := json.Marshal(settings)
 	if err != nil {
 		return nil, err
 	}
 
 	e := endpoint.ModifyGuildRole(r.guildID, id)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -131,11 +143,17 @@ func (r *GuildResource) ModifyRole(ctx context.Context, id string, settings *rol
 	return &role, nil
 }
 
+// DeleteRole is like DeleteRoleWithReason but with no particular reason.
+func (r *GuildResource) DeleteRole(ctx context.Context, id string) error {
+	return r.DeleteRoleWithReason(ctx, id, "")
+}
+
 // DeleteRole deletes a guild role. Requires the 'MANAGE_ROLES' permission.
 // Fires a Guild Role Delete Gateway event.
-func (r *GuildResource) DeleteRole(ctx context.Context, id string) error {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) DeleteRoleWithReason(ctx context.Context, id, reason string) error {
 	e := endpoint.DeleteGuildRole(r.guildID, id)
-	resp, err := r.client.doReq(ctx, e, nil)
+	resp, err := r.client.doReqWithHeader(ctx, e, nil, reasonHeader(reason))
 	if err != nil {
 		return err
 	}
@@ -147,11 +165,17 @@ func (r *GuildResource) DeleteRole(ctx context.Context, id string) error {
 	return nil
 }
 
+// AddMemberRole is like AddMemberRoleWithReason but with no particular reason.
+func (r *GuildResource) AddMemberRole(ctx context.Context, userID, roleID string) error {
+	return r.AddMemberRoleWithReason(ctx, userID, roleID, "")
+}
+
 // AddMemberRole adds a role to a guild member. Requires the 'MANAGE_ROLES'
 // permission. Fires a Guild Member Update Gateway event.
-func (r *GuildResource) AddMemberRole(ctx context.Context, userID, roleID string) error {
+// The given reason will be set in the audit log entry for this action.
+func (r *GuildResource) AddMemberRoleWithReason(ctx context.Context, userID, roleID, reason string) error {
 	e := endpoint.AddGuildMemberRole(r.guildID, userID, roleID)
-	resp, err := r.client.doReq(ctx, e, nil)
+	resp, err := r.client.doReqWithHeader(ctx, e, nil, reasonHeader(reason))
 	if err != nil {
 		return err
 	}

--- a/invite.go
+++ b/invite.go
@@ -74,7 +74,7 @@ func (r *InviteResource) Delete(ctx context.Context, reason string) (*Invite, er
 	return r.DeleteWithReason(ctx, "")
 }
 
-// Delete deletes the invite. Requires the MANAGE_CHANNELS permission.
+// DeleteWithReason deletes the invite. Requires the MANAGE_CHANNELS permission.
 // Returns the deleted invite on success.
 // The given reason will be set in the audit log entry for this action.
 func (r *InviteResource) DeleteWithReason(ctx context.Context, reason string) (*Invite, error) {

--- a/invite.go
+++ b/invite.go
@@ -69,11 +69,17 @@ func (r *InviteResource) Get(ctx context.Context, withCounts bool) (*Invite, err
 	return &invite, nil
 }
 
+// Delete is like DeleteWithReason but with no particular reason.
+func (r *InviteResource) Delete(ctx context.Context, reason string) (*Invite, error) {
+	return r.DeleteWithReason(ctx, "")
+}
+
 // Delete deletes the invite. Requires the MANAGE_CHANNELS permission.
 // Returns the deleted invite on success.
-func (r *InviteResource) Delete(ctx context.Context) (*Invite, error) {
+// The given reason will be set in the audit log entry for this action.
+func (r *InviteResource) DeleteWithReason(ctx context.Context, reason string) (*Invite, error) {
 	e := endpoint.DeleteInvite(r.code)
-	resp, err := r.client.doReq(ctx, e, nil)
+	resp, err := r.client.doReqWithHeader(ctx, e, nil, reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}

--- a/user.go
+++ b/user.go
@@ -113,7 +113,7 @@ func (r *CurrentUserResource) Modify(ctx context.Context, username, avatar strin
 	}
 
 	e := endpoint.ModifyCurrentUser()
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (r *CurrentUserResource) NewDM(ctx context.Context, recipientID string) (*C
 	}
 
 	e := endpoint.CreateDM()
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReq(ctx, e, jsonPayload(b))
 	if err != nil {
 		return nil, err
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -215,7 +215,7 @@ func (r *WebhookResource) Modify(ctx context.Context, settings *webhook.Settings
 	return r.ModifyWithReason(ctx, settings, "")
 }
 
-// Modify modifies the webhook. Requires the 'MANAGE_WEBHOOKS' permission.
+// ModifyWithReason modifies the webhook. Requires the 'MANAGE_WEBHOOKS' permission.
 // The given reason will be set in the audit log entry for this action.
 func (r *WebhookResource) ModifyWithReason(ctx context.Context, settings *webhook.Settings, reason string) (*Webhook, error) {
 	b, err := json.Marshal(settings)
@@ -246,7 +246,7 @@ func (r *WebhookResource) Delete(ctx context.Context) error {
 	return r.DeleteWithReason(ctx, "")
 }
 
-// Delete deletes the webhook.
+// DeleteWithReason deletes the webhook.
 // The given reason will be set in the audit log entry for this action.
 func (r *WebhookResource) DeleteWithReason(ctx context.Context, reason string) error {
 	e := endpoint.DeleteWebhook(r.webhookID)

--- a/webhook.go
+++ b/webhook.go
@@ -210,15 +210,21 @@ func (r *WebhookResource) Get(ctx context.Context) (*Webhook, error) {
 	return &w, nil
 }
 
-// Modify modifies the webhook. Requires the 'MANAGE_WEBHOOKS' permission.
+// Modify is like ModifyWithReason but with no particular reason.
 func (r *WebhookResource) Modify(ctx context.Context, settings *webhook.Settings) (*Webhook, error) {
+	return r.ModifyWithReason(ctx, settings, "")
+}
+
+// Modify modifies the webhook. Requires the 'MANAGE_WEBHOOKS' permission.
+// The given reason will be set in the audit log entry for this action.
+func (r *WebhookResource) ModifyWithReason(ctx context.Context, settings *webhook.Settings, reason string) (*Webhook, error) {
 	b, err := json.Marshal(settings)
 	if err != nil {
 		return nil, err
 	}
 
 	e := endpoint.ModifyWebhook(r.webhookID)
-	resp, err := r.client.doReq(ctx, e, b)
+	resp, err := r.client.doReqWithHeader(ctx, e, b, reasonHeader(reason))
 	if err != nil {
 		return nil, err
 	}
@@ -235,10 +241,16 @@ func (r *WebhookResource) Modify(ctx context.Context, settings *webhook.Settings
 	return &w, nil
 }
 
-// Delete deletes the webhook.
+// Delete is like DeleteWithReason but with no particular reason.
 func (r *WebhookResource) Delete(ctx context.Context) error {
+	return r.DeleteWithReason(ctx, "")
+}
+
+// Delete deletes the webhook.
+// The given reason will be set in the audit log entry for this action.
+func (r *WebhookResource) DeleteWithReason(ctx context.Context, reason string) error {
 	e := endpoint.DeleteWebhook(r.webhookID)
-	resp, err := r.client.doReq(ctx, e, nil)
+	resp, err := r.client.doReqWithHeader(ctx, e, nil, reasonHeader(reason))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

This PR adds the possibility to set a reason (showed in the audit log) when performing actions that support this feature.

Every methods that support this feature now have a `WithReason` form.

Example: 

```go
client.Channel("channel-id").Modify(ctx, settings)
```

now also have the following method: 

```go
client.Channel("channel-id").ModifyWithReason(ctx, settings, "reason for this change")
``` 