### PR TITLE
Bump go version to 1.12.x and golangci-ling to 1.17.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 go:
-  - 1.11.x
+  - 1.12.x
 install:
   - go get github.com/skwair/harmony
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.13.1
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.17.1
 script:
   - golangci-lint run
   - bash _scripts/build_examples.sh


### PR DESCRIPTION
### Description

This PR bumps the go version used by the CI as well as `golangci-lint` version.