### PR TITLE
Embed the client logger in the voice connection

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -34,8 +34,8 @@ func (c *Client) sendHeartbeatPayload() error {
 
 // heartbeat periodically sends a heartbeat payload to the voice server.
 func (vc *VoiceConnection) heartbeat(every time.Duration) {
-	vc.client.logger.Debug("starting voice connection heartbeater")
-	defer vc.client.logger.Debug("stopped voice connection heartbeater")
+	vc.logger.Debug("starting voice connection heartbeater")
+	defer vc.logger.Debug("stopped voice connection heartbeater")
 
 	heartbeat(&vc.wg, vc.stop, vc.error, every, vc.sendHeartbeatPayload, &vc.lastHeartbeatACK)
 }
@@ -99,8 +99,8 @@ func heartbeat(
 func (vc *VoiceConnection) udpHeartbeat(every time.Duration) {
 	defer vc.wg.Done()
 
-	vc.client.logger.Debug("starting UDP heartbeater")
-	defer vc.client.logger.Debug("stopped UDP heartbeater")
+	vc.logger.Debug("starting UDP heartbeater")
+	defer vc.logger.Debug("stopped UDP heartbeater")
 
 	ticker := time.NewTicker(every)
 	defer ticker.Stop()

--- a/listen.go
+++ b/listen.go
@@ -14,8 +14,8 @@ func (c *Client) listen() {
 
 // listen listens for payloads sent by the voice server.
 func (vc *VoiceConnection) listen() {
-	vc.client.logger.Debug("starting voice connection event listener")
-	defer vc.client.logger.Debug("stopped voice connection event listener")
+	vc.logger.Debug("starting voice connection event listener")
+	defer vc.logger.Debug("stopped voice connection event listener")
 
 	listen(&vc.wg, vc.stop, vc.error, vc.recvPayloads, vc.handleEvent)
 }

--- a/opus.go
+++ b/opus.go
@@ -33,8 +33,8 @@ func (vc *VoiceConnection) opusReceiver() {
 	vc.opusReadinessWG.Done()
 	defer vc.wg.Done()
 
-	vc.client.logger.Debug("starting Opus receiver")
-	defer vc.client.logger.Debug("stopped Opus receiver")
+	vc.logger.Debug("starting Opus receiver")
+	defer vc.logger.Debug("stopped Opus receiver")
 
 	rtpFrames := make(chan *rtpFrame)
 	go vc.readUDP(rtpFrames)
@@ -122,8 +122,8 @@ func (vc *VoiceConnection) opusSender() {
 	vc.opusReadinessWG.Done()
 	defer vc.wg.Done()
 
-	vc.client.logger.Debug("starting Opus sender")
-	defer vc.client.logger.Debug("stopped Opus sender")
+	vc.logger.Debug("starting Opus sender")
+	defer vc.logger.Debug("stopped Opus sender")
 
 	const (
 		sampleRate = 48000 // In Hz, the number of samples we take each second.


### PR DESCRIPTION
### Description

This PR makes `VoiceConnection` having its own logger instead of using the `Client`'s logger. It also exports it so it can be used in 3rd party packages, such as the upcoming `voiceutil` package.