### PR TITLE
Add the RateLimitPerUser property for Channels

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -25,8 +25,9 @@ type Channel struct {
 	LastMessageID        string                 `json:"last_message_id,omitempty"`
 
 	// For voice channels.
-	Bitrate   int `json:"bitrate,omitempty"`
-	UserLimit int `json:"user_limit,omitempty"`
+	Bitrate          int `json:"bitrate,omitempty"`
+	UserLimit        int `json:"user_limit,omitempty"`
+	RateLimitPerUser int `json:"rate_limit_per_user"`
 
 	// For DMs.
 	Recipients    []User `json:"recipients,omitempty"`


### PR DESCRIPTION
### Description

This PR adds the missing `RateLimitPerUser` property for channels.