### PR TITLE
Add the guild subscription option when creation a client

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,6 +74,8 @@ type Client struct {
 	largeThreshold int
 	// See WithSharding for more information.
 	shard [2]int
+	// See WithGuildSubscriptions for more information.
+	guildSubscriptions bool
 
 	userID    string
 	sessionID string
@@ -118,16 +120,17 @@ type Client struct {
 // ClientOption.
 func NewClient(token string, opts ...ClientOption) (*Client, error) {
 	c := &Client{
-		name:              "Harmony",
-		token:             "Bot " + token,
-		baseURL:           defaultBaseURL,
-		client:            http.DefaultClient,
-		limiter:           rate.NewLimiter(),
-		largeThreshold:    defaultLargeThreshold,
-		handlers:          make(map[string]handler),
-		backoff:           defaultBackoff,
-		withStateTracking: true,
-		logger:            log.NewStd(log.LevelError),
+		name:               "Harmony",
+		token:              "Bot " + token,
+		baseURL:            defaultBaseURL,
+		client:             http.DefaultClient,
+		limiter:            rate.NewLimiter(),
+		largeThreshold:     defaultLargeThreshold,
+		guildSubscriptions: true,
+		handlers:           make(map[string]handler),
+		backoff:            defaultBackoff,
+		withStateTracking:  true,
+		logger:             log.NewStd(log.LevelError),
 	}
 
 	for _, opt := range opts {

--- a/client_options.go
+++ b/client_options.go
@@ -40,11 +40,21 @@ func WithBaseURL(url string) ClientOption {
 
 // WithSharding allows you to specify a sharding configuration when connecting to the Gateway.
 // See https://discordapp.com/developers/docs/topics/gateway#sharding for more details.
-// Default to nothing, sharding is not enabled.
+// Defaults to nothing, sharding is not enabled.
 func WithSharding(current, total int) ClientOption {
 	return func(c *Client) {
 		c.shard[0] = current
 		c.shard[1] = total
+	}
+}
+
+// WithGuildSubscription allows to set whether the client should identify to the Gateway with
+// guild subscription enabled or not. Guild subscriptions are guild member presence updates
+// and typing events.
+// Defaults to true.
+func WithGuildSubscription(y bool) ClientOption {
+	return func(c *Client) {
+		c.guildSubscriptions = y
 	}
 }
 

--- a/identify.go
+++ b/identify.go
@@ -8,12 +8,13 @@ import (
 
 // identify is used to trigger the initial handshake with the gateway.
 type identify struct {
-	Token          string            `json:"token"`
-	Properties     map[string]string `json:"properties"`
-	Compress       bool              `json:"compress,omitempty"`
-	LargeThreshold int               `json:"large_threshold,omitempty"`
-	Shard          *[2]int           `json:"shard,omitempty"`
-	Presence       *Status           `json:"presence,omitempty"`
+	Token              string            `json:"token"`
+	Properties         map[string]string `json:"properties"`
+	Compress           bool              `json:"compress,omitempty"`
+	LargeThreshold     int               `json:"large_threshold,omitempty"`
+	Shard              *[2]int           `json:"shard,omitempty"`
+	Presence           *Status           `json:"presence,omitempty"`
+	GuildSubscriptions bool              `json:"guild_subscriptions"`
 }
 
 // Status is sent by the client to indicate a presence or status update.
@@ -32,8 +33,9 @@ func (c *Client) identify() error {
 			"$os":      strings.Title(runtime.GOOS),
 			"$browser": "github.com/skwair/harmony",
 		},
-		Compress:       true,
-		LargeThreshold: c.largeThreshold,
+		Compress:           true,
+		LargeThreshold:     c.largeThreshold,
+		GuildSubscriptions: c.guildSubscriptions,
 	}
 
 	if c.shard[1] != 0 {


### PR DESCRIPTION
### Description

This PR adds an option to disable Guild subscriptions (member status updates & typing events) when creating a client.