### PR TITLE
Fix UDP server IP and remove delay parameter when speaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ go test -v -race ./...
 
 # How does it compare to [DiscordGo](https://github.com/bwmarrin/discordgo)?
 
-DiscordGo offers some additional features right now, such as a way to create and manage your [Discord applications](https://discordapp.com/developers/applications/me). The majority of features though, such a receiving events, sending messages, receiving and sending voice data, etc. are also implemented in this library. Another thing that this library does not support is self bot, as they are a violation of Discord's TOS.
+DiscordGo offers some additional features right now, such as a way to create and manage your [Discord applications](https://discordapp.com/developers/applications/me). The majority of features though, such a receiving events, sending messages, ~receiving~ and sending voice data, etc. are also implemented in this library. Another thing that this library does not support is self bot, as they are a violation of Discord's TOS.
 
 The main difference resides in the Gateway (websocket) real time API implementation. This library takes a different approach (using more synchronisation mechanisms) to avoid having to rely on hacks like [this](https://github.com/bwmarrin/discordgo/blob/8325a6bf6dd6c91ed4040a1617b07287b8fb0eba/wsapi.go#L868) or [this](https://github.com/bwmarrin/discordgo/blob/8325a6bf6dd6c91ed4040a1617b07287b8fb0eba/wsapi.go#L822), hopefully providing a more robust implementation as well as a better user experience.
 

--- a/voice.go
+++ b/voice.go
@@ -59,7 +59,7 @@ func (c *Client) VoiceRegions(ctx context.Context, guildID string) ([]VoiceRegio
 
 // Speaking sends an Opcode 5 Speaking payload. This does nothing
 // if the user is already in the given state.
-func (vc *VoiceConnection) Speaking(s bool, delay int) error {
+func (vc *VoiceConnection) Speaking(s bool) error {
 	// Return early if the user is already in the asked state.
 	prev := atomic.LoadInt32(&vc.speaking)
 	if (prev == 1) == s {
@@ -78,7 +78,7 @@ func (vc *VoiceConnection) Speaking(s bool, delay int) error {
 		SSRC     uint32 `json:"ssrc"`
 	}{
 		Speaking: s,
-		Delay:    delay,
+		Delay:    0,
 		SSRC:     vc.ssrc,
 	}
 

--- a/voice_connection.go
+++ b/voice_connection.go
@@ -305,7 +305,7 @@ func (vc *VoiceConnection) connect() error {
 	}
 	vc.ssrc = vr.SSRC
 	// We should now be able to open the voice UDP connection.
-	host := fmt.Sprintf("%s:%d", strings.TrimSuffix(server.Endpoint, ":80"), vr.Port)
+	host := fmt.Sprintf("%s:%d", vr.IP, vr.Port)
 	vc.logger.Debugf("resolving voice connection UDP endpoint: %s", host)
 	addr, err := net.ResolveUDPAddr("udp", host)
 	if err != nil {
@@ -380,13 +380,13 @@ func (vc *VoiceConnection) connect() error {
 // Must send some audio packets so the voice server starts to send us audio packets.
 // This appears to be a bug from Discord.
 func (vc *VoiceConnection) sendSilenceFrame() error {
-	if err := vc.Speaking(true, 0); err != nil {
+	if err := vc.Speaking(true); err != nil {
 		return err
 	}
 
 	vc.Send <- silenceFrame
 
-	if err := vc.Speaking(false, 0); err != nil {
+	if err := vc.Speaking(false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Description

This PR fixes the UDP voice connection IP we send packets to. It also removes the possibility to specify a delay when invoking the Speaking method as it should only be useful for browser (see [this answer for more details](https://github.com/discordapp/discord-api-docs/issues/859#issuecomment-466602485)).

Also removes the fact that this library can receive audio from the Readme as it sometimes doesn't work (see [this for more info](https://github.com/discordapp/discord-api-docs/issues/808) :cry: )