### PR TITLE
Migrate to voice gateway version 4

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package harmony
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"sync"
@@ -132,6 +133,10 @@ type Client struct {
 // "self-bots"), are not supported. To customize a Client, refer to available
 // ClientOption.
 func NewClient(token string, opts ...ClientOption) (*Client, error) {
+	if token == "" {
+		return nil, errors.New("harmony: a token is mandatory to create a client")
+	}
+
 	c := &Client{
 		name:               "Harmony",
 		token:              "Bot " + token,

--- a/examples/03.files/main.go
+++ b/examples/03.files/main.go
@@ -54,7 +54,9 @@ func (b *bot) onNewMessage(m *harmony.Message) {
 		// use FileFromURL instead.
 		// If you already have your own reader, then FileFromReadCloser is the
 		// function you want to use.
-		file, err := harmony.FileFromDisk("discord-gopher.png", "zob")
+		// Leaving the name argument empty makes it default to the name of the
+		// file.
+		file, err := harmony.FileFromDisk("discord-gopher.png", "")
 		if err != nil {
 			log.Println(err)
 			return

--- a/gateway_connection.go
+++ b/gateway_connection.go
@@ -221,6 +221,13 @@ func (c *Client) onGatewayError(err error) {
 		c.resetGatewaySession()
 	}
 	c.logger.Errorf("gateway connection: %v", err)
+
+	// If an error occurred before the connection is established,
+	// the stop channel will already be closed, so return early.
+	if !c.isConnected() {
+		return
+	}
+
 	close(c.stop)
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -80,4 +80,4 @@ const (
 )
 
 // NewStd returns a new logger for Harmony based on the standard logger.
-func NewStd(w io.Writer, l Level) Logger { return &std{Logger: log.New(w, "", 0), level: l} }
+func NewStd(w io.Writer, l Level) Logger { return &std{Logger: log.New(w, "", log.LstdFlags), level: l} }

--- a/log/logger.go
+++ b/log/logger.go
@@ -74,6 +74,8 @@ func (s *std) printfWithPrefix(prefix, format string, v ...interface{}) {
 type Level int
 
 const (
+	// Beware of debug level which will log sensitive information
+	// such as bot tokens, voice connections secret keys, etc.
 	LevelDebug Level = 2
 	LevelInfo  Level = 1
 	LevelError Level = 0

--- a/message/message.go
+++ b/message/message.go
@@ -26,11 +26,11 @@ type Flag int
 
 const (
 	// This message has been published to subscribed channels (via Channel Following).
-	FlagCrossposted = 1 << 0
+	FlagCrossposted Flag = 1 << 0
 	// This message originated from a message in another channel (via Channel Following).
-	FlagIsCrosspost = 1 << 1
+	FlagIsCrosspost Flag = 1 << 1
 	// Do not include any embeds when serializing this message.
-	FlagSuppressEmbeds = 1 << 2
+	FlagSuppressEmbeds Flag = 1 << 2
 )
 
 // Attachment is a file attached to a message.

--- a/voice/connection.go
+++ b/voice/connection.go
@@ -27,7 +27,7 @@ var silenceFrame = []byte{0xf8, 0xff, 0xfe}
 // Connection represents a Discord voice connection.
 type Connection struct {
 	// General lock for long operations that should
-	// not happen concurrently like Close or SetSpeaking.
+	// not happen concurrently like Close or SetSpeakingMode.
 	mu sync.Mutex
 
 	// Send is used to send Opus encoded audio packets.
@@ -56,8 +56,8 @@ type Connection struct {
 	udpConn *net.UDPConn
 
 	// Holds the value of the last
-	//speaking (opcode 5) payload sent.
-	speaking SpeakingFlag
+	// speaking (opcode 5) payload sent.
+	speakingMode SpeakingMode
 
 	// Secret used to encrypt voice data.
 	secret [32]byte
@@ -398,13 +398,13 @@ func (vc *Connection) onDisconnect() {
 // Must send some audio packets so the voice server starts to send us audio packets.
 // This appears to be a bug from Discord.
 func (vc *Connection) sendSilenceFrame(ctx context.Context) error {
-	if err := vc.SetSpeaking(ctx, SpeakingFlagVoice); err != nil {
+	if err := vc.SetSpeakingMode(ctx, SpeakingModeVoice); err != nil {
 		return err
 	}
 
 	vc.Send <- silenceFrame
 
-	if err := vc.SetSpeaking(ctx, SpeakingFlagOff); err != nil {
+	if err := vc.SetSpeakingMode(ctx, SpeakingModeOff); err != nil {
 		return err
 	}
 

--- a/voice/payload.go
+++ b/voice/payload.go
@@ -59,10 +59,19 @@ func (vc *Connection) sendPayload(ctx context.Context, op int, d interface{}) er
 	if err != nil {
 		return err
 	}
-	return payload.Send(ctx, vc.conn, &payload.Payload{Op: op, D: b})
+	p := &payload.Payload{Op: op, D: b}
+	vc.logger.Debugf("sent voice payload (channel=%q): %s", vc.channelID, p)
+	return payload.Send(ctx, vc.conn, p)
 }
 
 // recvPayload receives a single Payload from the Voice server.
 func (vc *Connection) recvPayload() (*payload.Payload, error) {
-	return payload.Recv(vc.ctx, &vc.connRMu, vc.conn)
+	p, err := payload.Recv(vc.ctx, &vc.connRMu, vc.conn)
+	if err != nil {
+		return nil, err
+	}
+
+	vc.logger.Debugf("received voice payload (channel=%q): %s", vc.channelID, p)
+
+	return p, nil
 }

--- a/voice/speaking.go
+++ b/voice/speaking.go
@@ -2,40 +2,48 @@ package voice
 
 import (
 	"context"
-	"sync/atomic"
+)
+
+// SpeakingFlag is the type for flags that can be used as a bitwise mask for SetSpeaking.
+type SpeakingFlag uint32
+
+const (
+	// Normal transmission of audio.
+	SpeakingFlagVoice SpeakingFlag = 0x1
+	// Transmission of context audio for video, no speaking indicator.
+	SpeakingFlagSoundshare SpeakingFlag = 0x2
+	// Priority speaker, lowering audio of other speakers.
+	SpeakingFlagPriority SpeakingFlag = 0x4
+	// No audio transmission.
+	SpeakingFlagOff SpeakingFlag = 0x0
 )
 
 // Speaking sends an Opcode 5 Speaking payload. This does nothing
 // if the user is already in the given state.
-func (vc *Connection) Speaking(ctx context.Context, s bool) error {
+func (vc *Connection) SetSpeaking(ctx context.Context, speaking SpeakingFlag) error {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+
 	// Return early if the user is already in the asked state.
-	prev := atomic.LoadInt32(&vc.speaking)
-	if (prev == 1) == s {
+	if speaking == vc.speaking {
 		return nil
 	}
 
-	if s {
-		atomic.StoreInt32(&vc.speaking, 1)
-	} else {
-		atomic.StoreInt32(&vc.speaking, 0)
-	}
-
 	p := struct {
-		Speaking bool   `json:"speaking"`
+		Speaking uint32 `json:"speaking"`
 		Delay    int    `json:"delay"`
 		SSRC     uint32 `json:"ssrc"`
 	}{
-		Speaking: s,
+		Speaking: uint32(speaking),
 		Delay:    0,
 		SSRC:     vc.ssrc,
 	}
 
 	if err := vc.sendPayload(ctx, voiceOpcodeSpeaking, p); err != nil {
-		// If there is an error, reset our internal value to its previous
-		// state because the update was not acknowledged by Discord.
-		atomic.StoreInt32(&vc.speaking, prev)
 		return err
 	}
+
+	vc.speaking = speaking
 
 	return nil
 }

--- a/voice/speaking.go
+++ b/voice/speaking.go
@@ -4,28 +4,28 @@ import (
 	"context"
 )
 
-// SpeakingFlag is the type for flags that can be used as a bitwise mask for SetSpeaking.
-type SpeakingFlag uint32
+// SpeakingMode is the type for modes that can be used as a bitwise mask for SetSpeakingMode.
+type SpeakingMode uint32
 
 const (
 	// Normal transmission of audio.
-	SpeakingFlagVoice SpeakingFlag = 0x1
+	SpeakingModeVoice SpeakingMode = 0x1
 	// Transmission of context audio for video, no speaking indicator.
-	SpeakingFlagSoundshare SpeakingFlag = 0x2
+	SpeakingModeSoundshare SpeakingMode = 0x2
 	// Priority speaker, lowering audio of other speakers.
-	SpeakingFlagPriority SpeakingFlag = 0x4
+	SpeakingModePriority SpeakingMode = 0x4
 	// No audio transmission.
-	SpeakingFlagOff SpeakingFlag = 0x0
+	SpeakingModeOff SpeakingMode = 0x0
 )
 
-// Speaking sends an Opcode 5 Speaking payload. This does nothing
+// SetSpeakingMode sends an Opcode 5 Speaking payload. This does nothing
 // if the user is already in the given state.
-func (vc *Connection) SetSpeaking(ctx context.Context, speaking SpeakingFlag) error {
+func (vc *Connection) SetSpeakingMode(ctx context.Context, mode SpeakingMode) error {
 	vc.mu.Lock()
 	defer vc.mu.Unlock()
 
 	// Return early if the user is already in the asked state.
-	if speaking == vc.speaking {
+	if mode == vc.speakingMode {
 		return nil
 	}
 
@@ -34,7 +34,7 @@ func (vc *Connection) SetSpeaking(ctx context.Context, speaking SpeakingFlag) er
 		Delay    int    `json:"delay"`
 		SSRC     uint32 `json:"ssrc"`
 	}{
-		Speaking: uint32(speaking),
+		Speaking: uint32(mode),
 		Delay:    0,
 		SSRC:     vc.ssrc,
 	}
@@ -43,7 +43,7 @@ func (vc *Connection) SetSpeaking(ctx context.Context, speaking SpeakingFlag) er
 		return err
 	}
 
-	vc.speaking = speaking
+	vc.speakingMode = mode
 
 	return nil
 }

--- a/voice/voiceutil/pcm.go
+++ b/voice/voiceutil/pcm.go
@@ -7,9 +7,12 @@ import (
 )
 
 const (
-	sampleRate = 48000
-	channels   = 2
-	frameSize  = 960
+	// Number of channels supported.
+	Channels = 2
+	// Size of a single frame; this represents 20ms of audio sampled at 48kHz.
+	FrameSize = 960
+	// Sample rate used by Discord.
+	SampleRate = 48000
 )
 
 // OpusEncoder is an adapter that allows to send a PCM signal through the
@@ -21,7 +24,7 @@ const (
 //
 // Only one OpusEncoder is meant to be used at once on the same voice connection.
 func OpusEncoder(conn *voice.Connection) (pcmIn chan []int16, err error) {
-	enc, err := opus.NewEncoder(sampleRate, channels, opus.Audio)
+	enc, err := opus.NewEncoder(SampleRate, Channels, opus.Audio)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +37,7 @@ func OpusEncoder(conn *voice.Connection) (pcmIn chan []int16, err error) {
 				return
 			}
 
-			opusEncoded, err := enc.Encode(pcm, frameSize, frameSize*2*2)
+			opusEncoded, err := enc.Encode(pcm, FrameSize, FrameSize*2*2)
 			if err != nil {
 				conn.Logger().Errorf("could not encode PCM data: %v", err)
 				return
@@ -77,14 +80,14 @@ func OpusDecoder(conn *voice.Connection) (pcmOut chan []int16, free chan struct{
 
 			if _, ok = speakers[packet.SSRC]; !ok {
 				var err error
-				speakers[packet.SSRC], err = opus.NewDecoder(sampleRate, channels)
+				speakers[packet.SSRC], err = opus.NewDecoder(SampleRate, Channels)
 				if err != nil {
 					conn.Logger().Errorf("could not create Opus decoder: %v", err)
 					return
 				}
 			}
 
-			pcm, err := speakers[packet.SSRC].Decode(packet.Opus, frameSize, false)
+			pcm, err := speakers[packet.SSRC].Decode(packet.Opus, FrameSize, false)
 			if err != nil {
 				conn.Logger().Errorf("could not decode Opus data: %v", err)
 				return


### PR DESCRIPTION
### Description

This PR migrates to voice gateway version 4. This version adds support for `SpeakingMode` (for soundshare and priority speaker), and changes the signature of `VoiceConnection.Speaking` to `VoiceConnection.SetSpeakingMode`.

It also adds some logging for voice connections payloads as well as the date and hour to every logs.