### PR TITLE
Fix voice channel leave

### DIFF
--- a/voice/opus.go
+++ b/voice/opus.go
@@ -113,7 +113,10 @@ func (vc *Connection) readUDP(ch chan<- *rtpFrame) {
 			continue
 		}
 
-		ch <- &rtpFrame{raw: buf, size: l}
+		select {
+		case ch <- &rtpFrame{raw: buf, size: l}:
+		default:
+		}
 	}
 }
 

--- a/voice/opus.go
+++ b/voice/opus.go
@@ -113,6 +113,8 @@ func (vc *Connection) readUDP(ch chan<- *rtpFrame) {
 			continue
 		}
 
+		// Only send voice data through the channel if someone is listening
+		// on the other side, else we'll just block forever.
 		select {
 		case ch <- &rtpFrame{raw: buf, size: l}:
 		default:


### PR DESCRIPTION
### Description

This PR fixes a bug where the bot would never leave a voice channel if it received some audio data from this channel but nothing was listening on the connection's `Recv` channel.

Fixes #53 