### PR TITLE
Fix websocket status code when closing connections

### DIFF
--- a/gateway_connection.go
+++ b/gateway_connection.go
@@ -70,7 +70,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	// this client as not connected.
 	defer func() {
 		if err != nil {
-			_ = c.conn.Close(websocket.StatusAbnormalClosure, "failed to establish connection") // Not much we can do about this, maybe log it?
+			_ = c.conn.Close(websocket.StatusInternalError, "failed to establish connection") // Not much we can do about this, maybe log it?
 			atomic.StoreInt32(&c.connected, 0)
 			close(c.stop)
 			c.cancel()
@@ -213,14 +213,17 @@ func (c *Client) reconnectWithBackoff() {
 // with a 1006 code, logs the error and finally signals to all other
 // goroutines (heartbeat, listen, etc.) to stop by closing the stop channel.
 func (c *Client) onGatewayError(err error) {
-	if closeErr := c.conn.Close(websocket.StatusAbnormalClosure, "gateway error"); closeErr != nil {
+	if closeErr := c.conn.Close(websocket.StatusInternalError, "gateway error"); closeErr != nil {
 		c.logger.Errorf("could not properly close websocket connection (error): %v", closeErr)
-		// If we can't properly close the websocket connection,
-		// we should reset our session so the next call to Connect
-		// won't try to resume a corrupted session forever.
-		c.resetGatewaySession()
 	}
 	c.logger.Errorf("gateway connection: %v", err)
+
+	// If an error occurred before the connection is established,
+	// the stop channel will already be closed, so return early.
+	if !c.isConnected() {
+		return
+	}
+
 	close(c.stop)
 }
 

--- a/internal/payload/listen.go
+++ b/internal/payload/listen.go
@@ -52,13 +52,16 @@ func RecvAll(
 	for {
 		p, err := receiver()
 		if err != nil {
-			// Silently break out of this loop because
-			// the connection was closed by the client.
-			if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
+			// Silently break out of this loop because the connection
+			// was closed (either intentionally by calling Disconnect
+			// or because we encountered an error).
+			if websocket.CloseStatus(err) == websocket.StatusNormalClosure ||
+				websocket.CloseStatus(err) == websocket.StatusInternalError {
 				return
 			}
 
-			// NOTE: maybe treat websocket close errors differently based on their code.
+			// NOTE: maybe treat websocket close errors differently based on their code
+			// for the 4000-4999 range.
 			// See : https://discordapp.com/developers/docs/topics/opcodes-and-status-codes
 
 			errCh <- err

--- a/voice/connection.go
+++ b/voice/connection.go
@@ -193,7 +193,7 @@ func EstablishNewConnection(ctx context.Context, state *StateUpdate, server *Ser
 	// websocket so we can try to reconnect.
 	defer func() {
 		if err != nil {
-			_ = vc.conn.Close(websocket.StatusAbnormalClosure, "failed to establish voice connection")
+			_ = vc.conn.Close(websocket.StatusInternalError, "failed to establish voice connection")
 			atomic.StoreInt32(&vc.connected, 0)
 			close(vc.stop)
 			vc.cancel()
@@ -370,7 +370,7 @@ func (vc *Connection) wait() {
 // with a 1006 code, logs the error and finally signals to all other
 // goroutines (heartbeat, listen, etc.) to stop by closing the stop channel.
 func (vc *Connection) onError(err error) {
-	if closeErr := vc.conn.Close(websocket.StatusAbnormalClosure, "voice error"); closeErr != nil {
+	if closeErr := vc.conn.Close(websocket.StatusInternalError, "voice error"); closeErr != nil {
 		vc.logger.Errorf("could not properly close voice websocket connection: %v", closeErr)
 		vc.logger.Errorf("voice connection: %v", err)
 	}


### PR DESCRIPTION
### Description

This PR removes the use of the websocket `StatusAbnormalClosure` code which is not intended to be used as it was as per the [RFC](https://tools.ietf.org/html/rfc6455#section-7.4.1).

Also, It prevents the Gateway session to be cleared when there is an error while closing the websocket connection so sessions can properly resume.