### PR TITLE
Force activity timestamp to be 64-bit to be compatible with 32-bit arch

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -35,8 +35,8 @@ type Activity struct {
 // ActivityTimestamp is the unix time (in milliseconds) of when the
 // activity starts and ends.
 type ActivityTimestamp struct {
-	Start int `json:"start,omitempty"`
-	End   int `json:"end,omitempty"`
+	Start int64 `json:"start,omitempty"`
+	End   int64 `json:"end,omitempty"`
 }
 
 // ActivityParty contains information for the current party of the player.


### PR DESCRIPTION
### Description

This PR forces the `ActivityTimestamp` fields to be 64 bits to avoid errors on 32 bits machines.