### PR TITLE
Fix guild voice states in client state

### DIFF
--- a/state.go
+++ b/state.go
@@ -344,7 +344,7 @@ func (s *State) updateGuildVoiceStates(vsu *voice.StateUpdate) {
 		// Find the index of the voice state update to remove.
 		var toRemove int
 		for i, update := range g.VoiceStates {
-			if update.GuildID == vsu.GuildID {
+			if update.UserID == vsu.UserID {
 				toRemove = i
 			}
 		}


### PR DESCRIPTION
### Description

This PR fixes an error in the `updateGuildVoiceStates` method that prevented the `State` to be correctly updated and that could lead to panics.