### PR TITLE
Properly stop reconnect loop with Disconnect

### DIFF
--- a/internal/payload/listen.go
+++ b/internal/payload/listen.go
@@ -45,6 +45,7 @@ func RecvAll(
 	wg *sync.WaitGroup,
 	payloads chan<- *Payload,
 	errCh chan<- error,
+	stop <-chan struct{},
 	receiver func() (*Payload, error),
 ) {
 	defer wg.Done()
@@ -68,6 +69,10 @@ func RecvAll(
 			return
 		}
 
-		payloads <- p
+		select {
+		case payloads <- p:
+		case <-stop:
+			return
+		}
 	}
 }

--- a/listen.go
+++ b/listen.go
@@ -20,5 +20,5 @@ func (c *Client) listen() {
 }
 
 func (c *Client) recvPayloads(ch chan<- *payload.Payload) {
-	payload.RecvAll(&c.wg, ch, c.error, c.recvPayload)
+	payload.RecvAll(&c.wg, ch, c.error, c.stop, c.recvPayload)
 }

--- a/voice/listen.go
+++ b/voice/listen.go
@@ -17,5 +17,5 @@ func (vc *Connection) listen() {
 }
 
 func (vc *Connection) recvPayloads(ch chan<- *payload.Payload) {
-	payload.RecvAll(&vc.wg, ch, vc.error, vc.recvPayload)
+	payload.RecvAll(&vc.wg, ch, vc.error, vc.stop, vc.recvPayload)
 }


### PR DESCRIPTION
### Description

This PR properly breaks the re-connection loop when the user calls `Disconnect`. It also improves heartbeats error logs.