### PR TITLE
Switch from `discordapp.com` to `discord.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <img align="right" height="200" src=".github/discord-gopher.png">
 
-Harmony is a peaceful [Go](https://golang.org) module for interacting with [Discord](http://discordapp.com)'s API.
+Harmony is a peaceful [Go](https://golang.org) module for interacting with [Discord](https://discord.com)'s API.
 
 Although this package is usable, it still is under active development so please don't use it for anything other than experiments, yet.
 
@@ -51,11 +51,12 @@ func main() {
         log.Fatal(err)
     }
 
-    // Get information about the current user.
+    // Get information about the current user (the bot itself).
     u, err := client.CurrentUser().Get(context.Background())
     if err != nil {
         log.Fatal(err)
     }
+
     fmt.Println(u)
 }
 ```
@@ -96,7 +97,7 @@ Harmony exposes its API differently. It uses a [resource-based](https://godoc.or
 
 Another key difference is in the "event handler" mechanism. Instead of having a single [method](https://github.com/bwmarrin/discordgo/blob/dd99dea7adba674baa401e52362d6e330b50acf8/event.go#L120) that takes an `interface{}` as a parameter and guesses for which event you registered a handler based on its concrete type, this library provides a dedicated method for each event type, making it clear what signature your handler must have and ensuring it at compile time, not at runtime.
 
-Each action that results in an entry in the audit log has a `...WithReason` form, allowing to set a reason for the change (see the `X-Audit-Log-Reason` [header](https://discordapp.com/developers/docs/resources/audit-log#audit-logs) documentation for more information).
+Each action that results in an entry in the audit log has a `...WithReason` form, allowing to set a reason for the change (see the `X-Audit-Log-Reason` [header](https://discord.com/developers/docs/resources/audit-log#audit-logs) documentation for more information).
 
 Finally, this library has a full support of the [context](https://golang.org/pkg/context/) package, allowing the use of timeouts, deadlines and cancellation when interacting with Discord's API.
 

--- a/audit/change_key.go
+++ b/audit/change_key.go
@@ -3,7 +3,7 @@ package audit
 type changeKey string
 
 // Possible change key values, as defined here:
-// https://discordapp.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key
+// https://discord.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key
 const (
 	changeKeyName                       changeKey = "name"
 	changeKeyIconHash                   changeKey = "icon_hash"

--- a/audit/entry_type.go
+++ b/audit/entry_type.go
@@ -6,7 +6,7 @@ import "github.com/skwair/harmony/permission"
 type EntryType int
 
 // Possible entry type values, as defined here:
-// https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
+// https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
 const (
 	EntryTypeGuildUpdate            EntryType = 1
 	EntryTypeChannelCreate          EntryType = 10

--- a/channel.go
+++ b/channel.go
@@ -304,7 +304,7 @@ func (r *ChannelResource) NewWebhook(ctx context.Context, name, avatar string) (
 // NewWebhookWithReason creates a new webhook for the channel. Requires the 'MANAGE_WEBHOOKS'
 // permission.
 // name must contain between 2 and 32 characters. avatar is an avatar data string,
-// see https://discordapp.com/developers/docs/resources/user#avatar-data for more info.
+// see https://discord.com/developers/docs/resources/user#avatar-data for more info.
 // It can be left empty to have the default avatar.
 // The given reason will be set in the audit log entry for this action.
 func (r *ChannelResource) NewWebhookWithReason(ctx context.Context, name, avatar, reason string) (*Webhook, error) {

--- a/channel_message.go
+++ b/channel_message.go
@@ -71,13 +71,13 @@ type Message struct {
 // endpoint requires the 'VIEW_CHANNEL' permission to be present on the current user. If the
 // current user is missing the 'READ_MESSAGE_HISTORY' permission in the channel then this will
 // return no messages (since they cannot read the message history).
-// The query parameter is a message ID prefixed with one of the following character :
+// The query parameter is a message ID prefixed with one of the following character:
 //	- '>' for fetching messages after
 //	- '<' for fetching messages before
 //	- '~' for fetching messages around
 // For example, to retrieve 50 messages around (25 before, 25 after) a message having the
 // ID 221588207995121520, set query to "~221588207995121520".
-// Limit is a positive integer between 1 and 100 that default to 50 if set to 0.
+// Limit is a positive integer between 1 and 100 that defaults to 50 if set to 0.
 func (r *ChannelResource) Messages(ctx context.Context, query string, limit int) ([]Message, error) {
 	if query == "" {
 		return nil, errors.New("empty query")

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultBaseURL        = "https://discordapp.com/api/v6"
+	defaultBaseURL        = "https://discord.com/api/v6"
 	defaultLargeThreshold = 250
 )
 

--- a/client_options.go
+++ b/client_options.go
@@ -39,7 +39,7 @@ func WithBaseURL(url string) ClientOption {
 }
 
 // WithSharding allows you to specify a sharding configuration when connecting to the Gateway.
-// See https://discordapp.com/developers/docs/topics/gateway#sharding for more details.
+// See https://discord.com/developers/docs/topics/gateway#sharding for more details.
 // Defaults to nothing, sharding is not enabled.
 func WithSharding(current, total int) ClientOption {
 	return func(c *Client) {
@@ -69,7 +69,7 @@ func WithStateTracking(y bool) ClientOption {
 
 // WithLargeThreshold allows you to set the large threshold when connecting to the Gateway.
 // This threshold will dictate the number of offline guild members are returned with a guild.
-// See: https://discordapp.com/developers/docs/topics/gateway#request-guild-members for more details.
+// See: https://discord.com/developers/docs/topics/gateway#request-guild-members for more details.
 // Defaults to 250.
 func WithLargeThreshold(t int) ClientOption {
 	return func(c *Client) {

--- a/examples/02.embed/main.go
+++ b/examples/02.embed/main.go
@@ -57,8 +57,8 @@ func (b *bot) onNewMessage(m *harmony.Message) {
 	if m.Content == "!embed" {
 		e := embed.New().
 			Title("title ~~(did you know you can have markdown here too?)~~").
-			Description("this supports [named links](https://discordapp.com) on top of the previously shown subset of markdown. ```\nyes, even code blocks```").
-			URL("https://discordapp.com").
+			Description("this supports [named links](https://discord.com) on top of the previously shown subset of markdown. ```\nyes, even code blocks```").
+			URL("https://discord.com").
 			Color(0x2491ec). // Hexadecimal color code.
 			Timestamp(time.Now()).
 			Footer(embed.NewFooter().
@@ -68,7 +68,7 @@ func (b *bot) onNewMessage(m *harmony.Message) {
 			Image(embed.NewImage("https://cdn.discordapp.com/embed/avatars/0.png")).
 			Author(embed.NewAuthor().
 				Name("author name").
-				URL("https://discordapp.com").
+				URL("https://discord.com").
 				IconURL("https://cdn.discordapp.com/embed/avatars/0.png").
 				Build()).
 			Fields(

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@
 
 In Discord, bots are attached to applications. So you will first need to create one, then attach a bot to this application.
 
-1. Head to [your applications](https://discordapp.com/developers/applications) and create a new one.
+1. Head to [your applications](https://discord.com/developers/applications) and create a new one.
 2. You will be presented a pop-up where you can set the name for the application as well as the team you want it to be linked to (chose personal if you don't know what it is).
 3. Then you will need to go to the `Bot` tab on the right and click the `Add Bot` button to attach a bot to your application.
 4. (optional) You can uncheck the `Public Bot` checkbox for now if you do not want anyone to be able to add your bot to their servers.
@@ -20,7 +20,7 @@ In Discord, bots are attached to applications. So you will first need to create 
 
 ## Adding a bot to a server
 
-1. Go to [your applications](https://discordapp.com/developers/applications) and select the application linked to the bot you want to add to a server.
+1. Go to [your applications](https://discord.com/developers/applications) and select the application linked to the bot you want to add to a server.
 2. In the `OAuth2` tab on the right, you will find an `OAUTH2 URL GENERATOR` section.
 3. Check the `Bot` checkbox under in the `SCOPES` list. A list of permissions will appear below the `SCOPES` list.
 4. Select which permissions you want your bot to have when added to a server. Note that those are the permissions your bot will ask, but it doesn't mean your bot users will grant them all. Also, note that if you don't select any permission here, your bot won't be able to do anything.

--- a/gateway_connection.go
+++ b/gateway_connection.go
@@ -210,7 +210,7 @@ func (c *Client) wait() {
 }
 
 // Determine whether we should try to reconnect based on the error we got.
-// See https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes for more information.
+// See https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes for more information.
 func shouldReconnect(err error) bool {
 	if err == nil {
 		return false

--- a/handle_event.go
+++ b/handle_event.go
@@ -58,7 +58,7 @@ func (c *Client) handleEvent(p *payload.Payload) error {
 			// If we could not resume a session in time, we will receive an
 			// Invalid Session payload and are expected to wait a bit before
 			// sending a fresh Identify payload.
-			// https://discordapp.com/developers/docs/topics/gateway#resuming.
+			// https://discord.com/developers/docs/topics/gateway#resuming.
 			time.Sleep(time.Duration(rand.Intn(5)+1) * time.Second)
 
 			c.resetGatewaySession()

--- a/harmony.go
+++ b/harmony.go
@@ -1,6 +1,6 @@
 /*
 Package harmony provides an interface to the Discord API
-(https://discordapp.com/developers/docs/intro).
+(https://discord.com/developers/docs/intro).
 
 Getting started
 

--- a/snowflake.go
+++ b/snowflake.go
@@ -6,7 +6,7 @@ import (
 )
 
 // CreationTimeOf returns the creation time of the given Discord ID (userID, guildID, channelID).
-// For more information, see : https://discordapp.com/developers/docs/reference#snowflakes.
+// For more information, see : https://discord.com/developers/docs/reference#snowflakes.
 func CreationTimeOf(id string) (time.Time, error) {
 	i, err := strconv.ParseInt(id, 10, 64)
 	if err != nil {

--- a/voice/connection.go
+++ b/voice/connection.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Five silence frames should be sent when there is a break in the sent data.
-// See https://discordapp.com/developers/docs/topics/voice-connections#voice-data-interpolation for more information.
+// See https://discord.com/developers/docs/topics/voice-connections#voice-data-interpolation for more information.
 var SilenceFrame = []byte{0xf8, 0xff, 0xfe}
 
 // Connection represents a Discord voice connection.

--- a/voice/opus.go
+++ b/voice/opus.go
@@ -173,7 +173,7 @@ func (vc *Connection) opusSender() {
 
 			// Generate the nonce from the rtpHeader. Since the RTP header is only 12 bytes
 			// long, it will leave the 12 trailing bytes of the nonce null, as specified by
-			// https://discordapp.com/developers/docs/topics/voice-connections#encrypting-and-sending-voice.
+			// https://discord.com/developers/docs/topics/voice-connections#encrypting-and-sending-voice.
 			copy(nonce[:], rtpHeader)
 
 			buf := secretbox.Seal(rtpHeader, data, &nonce, &vc.secret)

--- a/voice/reconnect.go
+++ b/voice/reconnect.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Determine whether we should try to reconnect based on the error we got.
-// See https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes for more information.
+// See https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes for more information.
 func shouldReconnect(err error) bool {
 	if err == nil {
 		return false

--- a/webhook/settings.go
+++ b/webhook/settings.go
@@ -6,7 +6,7 @@ import "github.com/skwair/harmony/optional"
 type Settings struct {
 	Name *optional.String `json:"name,omitempty"`
 	// Avatar is a data URI scheme that support JPG, GIF, and PNG formats, see
-	// https://discordapp.com/developers/docs/resources/user#avatar-data
+	// https://discord.com/developers/docs/resources/user#avatar-data
 	// for more information.
 	Avatar    *optional.String `json:"avatar,omitempty"`
 	ChannelID *optional.String `json:"channel_id,omitempty"`


### PR DESCRIPTION
### Description

As announced recently by Discord, they are moving from `discordapp.com` to `discord.com` for all endpoints but the CDN for now. This PR reflects this change (and fixes a typo or two).