### PR TITLE
New Warning Log Level

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -17,8 +17,12 @@ type Logger interface {
 	Debugf(format string, v ...interface{})
 	Info(v ...interface{})
 	Infof(format string, v ...interface{})
+	Warn(v ...interface{})
+	Warnf(format string, v ...interface{})
 	Error(v ...interface{})
 	Errorf(format string, v ...interface{})
+
+	Level() Level
 }
 
 type std struct {
@@ -50,6 +54,18 @@ func (s *std) Infof(format string, v ...interface{}) {
 	}
 }
 
+func (s *std) Warn(v ...interface{}) {
+	if s.level >= LevelWarn {
+		s.printWithPrefix("[WARN]", v...)
+	}
+}
+
+func (s *std) Warnf(format string, v ...interface{}) {
+	if s.level >= LevelWarn {
+		s.printfWithPrefix("[WARN]", format, v...)
+	}
+}
+
 func (s *std) Error(v ...interface{}) {
 	if s.level >= LevelError {
 		s.printWithPrefix("[ERROR]", v...)
@@ -60,6 +76,10 @@ func (s *std) Errorf(format string, v ...interface{}) {
 	if s.level >= LevelError {
 		s.printfWithPrefix("[ERROR]", format, v...)
 	}
+}
+
+func (s *std) Level() Level {
+	return s.level
 }
 
 func (s *std) printWithPrefix(prefix string, v ...interface{}) {
@@ -74,10 +94,23 @@ func (s *std) printfWithPrefix(prefix, format string, v ...interface{}) {
 type Level int
 
 const (
-	// Beware of debug level which will log sensitive information
-	// such as bot tokens, voice connections secret keys, etc.
-	LevelDebug Level = 2
-	LevelInfo  Level = 1
+	// LevelDebug traces everything Harmony does, it dumps every HTTP call
+	// and logs every websocket message. Very useful for debugging or developing
+	// new features.
+	// Beware of debug level as it is very chatty and it will log sensitive
+	// information such as bot tokens, voice connections secret keys, etc.
+	LevelDebug Level = 3
+	// LevelInfo is here to notify that something happened. There's generally nothing to do
+	// about them, they are just here to inform about an event.
+	// This is also the default log level of Harmony.
+	LevelInfo Level = 2
+	// LevelWarn is for important logs that indicates something wrong or unusual happened.
+	// The application is still running but probably in a degraded way and might crash if
+	// no action is taken to fix the issues reported.
+	LevelWarn Level = 1
+	// LevelError is for when something went really wrong, meaning the connection to the
+	// Gateway is probably down and/or failed to reconnect. These are very often network
+	// issues.
 	LevelError Level = 0
 )
 

--- a/request.go
+++ b/request.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/skwair/harmony/internal/endpoint"
+	"github.com/skwair/harmony/log"
 )
 
 // requestPayload is a payload that is sent to Discord's REST API.
@@ -84,8 +85,10 @@ func (c *Client) doReqWithHeader(ctx context.Context, e *endpoint.Endpoint, p *r
 
 	c.limiter.Wait(e.Key)
 
-	b, _ := httputil.DumpRequestOut(req, true)
-	c.logger.Debug("--> ", string(b))
+	if c.logger.Level() == log.LevelDebug {
+		b, _ := httputil.DumpRequestOut(req, true)
+		c.logger.Debug("--> ", string(b))
+	}
 
 	before := time.Now()
 
@@ -94,8 +97,10 @@ func (c *Client) doReqWithHeader(ctx context.Context, e *endpoint.Endpoint, p *r
 		return nil, err
 	}
 
-	b, _ = httputil.DumpResponse(resp, true)
-	c.logger.Debug("<-- ", time.Since(before), "\n", string(b))
+	if c.logger.Level() == log.LevelDebug {
+		b, _ := httputil.DumpResponse(resp, true)
+		c.logger.Debug("<-- ", time.Since(before), "\n", string(b))
+	}
 
 	c.limiter.Update(e.Key, resp.Header)
 


### PR DESCRIPTION
### Description

This PR adds a new `WARN` log level that will be used in an upcoming PR improving rate limiting. Also, it adds a new `Level` method on the logger to get its current level. This is used to only generate HTTP request dumps when we actually need them.