### PR TITLE
Add support for Gateway Intents

### DIFF
--- a/client.go
+++ b/client.go
@@ -83,6 +83,8 @@ type Client struct {
 	shard [2]int
 	// See WithGuildSubscriptions for more information.
 	guildSubscriptions bool
+	// See WithGatewayIntents for more information.
+	intents GatewayIntent
 
 	userID    string
 	sessionID string
@@ -156,6 +158,7 @@ func NewClient(token string, opts ...ClientOption) (*Client, error) {
 		limiter:            rate.NewLimiter(),
 		largeThreshold:     defaultLargeThreshold,
 		guildSubscriptions: true,
+		intents:            GatewayIntentUnprivileged,
 		handlers:           make(map[string]handler),
 		backoff:            defaultBackoff,
 		withStateTracking:  true,

--- a/client_options.go
+++ b/client_options.go
@@ -62,7 +62,7 @@ func WithGuildSubscriptions(y bool) ClientOption {
 
 // WithGatewayIntents allows to customize which Gateway Intents the client should subscribe to.
 // See https://discord.com/developers/docs/topics/gateway#gateway-intents for more information.
-// By default, the client subscribes to all events.
+// By default, the client subscribes to all unprivileged events.
 func WithGatewayIntents(i GatewayIntent) ClientOption {
 	return func(c *Client) {
 		c.intents = i

--- a/client_options.go
+++ b/client_options.go
@@ -48,13 +48,24 @@ func WithSharding(current, total int) ClientOption {
 	}
 }
 
-// WithGuildSubscription allows to set whether the client should identify to the Gateway with
+// WithGuildSubscriptions allows to set whether the client should identify to the Gateway with
 // guild subscription enabled or not. Guild subscriptions are guild member presence updates
 // and typing events.
 // Defaults to true.
-func WithGuildSubscription(y bool) ClientOption {
+// While not deprecated, Guild Subscriptions have been superseded by Gateway Intents. It is recommended
+// to use WithGatewayIntents for better results.
+func WithGuildSubscriptions(y bool) ClientOption {
 	return func(c *Client) {
 		c.guildSubscriptions = y
+	}
+}
+
+// WithGatewayIntents allows to customize which Gateway Intents the client should subscribe to.
+// See https://discord.com/developers/docs/topics/gateway#gateway-intents for more information.
+// By default, the client subscribes to all events.
+func WithGatewayIntents(i GatewayIntent) ClientOption {
+	return func(c *Client) {
+		c.intents = i
 	}
 }
 

--- a/gateway_intent.go
+++ b/gateway_intent.go
@@ -1,0 +1,26 @@
+package harmony
+
+// GatewayIntent specifies which events the Gateway should send to a client.
+type GatewayIntent int
+
+// List of gateway intents a client can subscribe to.
+const (
+	GatewayIntentGuild                  GatewayIntent = 1 << 0
+	GatewayIntentGuildMembers           GatewayIntent = 1 << 1
+	GatewayIntentGuildBans              GatewayIntent = 1 << 2
+	GatewayIntentGuildEmojis            GatewayIntent = 1 << 3
+	GatewayIntentGuildIntegrations      GatewayIntent = 1 << 4
+	GatewayIntentGuildWebhooks          GatewayIntent = 1 << 5
+	GatewayIntentGuildInvites           GatewayIntent = 1 << 6
+	GatewayIntentGuildVoiceStates       GatewayIntent = 1 << 7
+	GatewayIntentGuildPresences         GatewayIntent = 1 << 8
+	GatewayIntentGuildMessages          GatewayIntent = 1 << 9
+	GatewayIntentGuildMessageReactions  GatewayIntent = 1 << 10
+	GatewayIntentGuildMessageTyping     GatewayIntent = 1 << 11
+	GatewayIntentDirectMessages         GatewayIntent = 1 << 12
+	GatewayIntentDirectMessageReactions GatewayIntent = 1 << 13
+	GatewayIntentDirectMessageTyping    GatewayIntent = 1 << 14
+)
+
+// Equivalent to all intents except privileged (GatewayIntentGuildMembers and GatewayIntentGuildPresences), OR'd.
+const GatewayIntentUnprivileged = GatewayIntentGuild | GatewayIntentGuildBans | GatewayIntentGuildEmojis | GatewayIntentGuildIntegrations | GatewayIntentGuildWebhooks | GatewayIntentGuildInvites | GatewayIntentGuildVoiceStates | GatewayIntentGuildMessages | GatewayIntentGuildMessageReactions | GatewayIntentGuildMessageTyping | GatewayIntentDirectMessages | GatewayIntentDirectMessageReactions | GatewayIntentDirectMessageTyping

--- a/identify.go
+++ b/identify.go
@@ -15,6 +15,7 @@ type identify struct {
 	Shard              *[2]int           `json:"shard,omitempty"`
 	Presence           *Status           `json:"presence,omitempty"`
 	GuildSubscriptions bool              `json:"guild_subscriptions"`
+	Intents            GatewayIntent     `json:"intents"`
 }
 
 // Status is sent by the client to indicate a presence or status update.
@@ -36,6 +37,7 @@ func (c *Client) identify(ctx context.Context) error {
 		Compress:           true,
 		LargeThreshold:     c.largeThreshold,
 		GuildSubscriptions: c.guildSubscriptions,
+		Intents:            c.intents,
 	}
 
 	if c.shard[1] != 0 {

--- a/internal/payload/payload.go
+++ b/internal/payload/payload.go
@@ -52,7 +52,7 @@ func (p *Payload) String() string {
 	return s.String()
 }
 
-// Send sends the given Payload, ensuring no concurrent call to conn.WriteJSON can occur.
+// Send sends the given Payload on the given connection.
 func Send(ctx context.Context, conn *websocket.Conn, p *Payload) error {
 	return wsjson.Write(ctx, conn, p)
 }


### PR DESCRIPTION
### Description

This PR adds support for [Gateway Intents](https://discord.com/developers/docs/topics/gateway#gateway-intents). A new function has been added to choose which intents a client should subscribe to when it's created:

```go
// WithGatewayIntents allows to customize which Gateway Intents the client should subscribe to.
// See https://discord.com/developers/docs/topics/gateway#gateway-intents for more information.
// By default, the client subscribes to all events.
func WithGatewayIntents(i GatewayIntent) ClientOption { /* ... */}
```

By default, a client subscribes to all unprivileged intents.

Also, a typo has been fixed in the `WithGuildSubscriptions` function.