### PR TITLE
Add support for the Delete All Reactions for Emoji endpoint

### DIFF
--- a/channel_message.go
+++ b/channel_message.go
@@ -464,6 +464,22 @@ func (r *ChannelResource) RemoveAllReactions(ctx context.Context, messageID stri
 	return nil
 }
 
+// RemoveAllReactionsForEmoji removes all reactions for the given emoji on a message. This endpoint requires
+// the 'MANAGE_MESSAGES' permission to be present on the current user.
+func (r *ChannelResource) RemoveAllReactionsForEmoji(ctx context.Context, messageID, emoji string) error {
+	e := endpoint.DeleteAllReactionsForEmoji(r.channelID, messageID, url.PathEscape(emoji))
+	resp, err := r.client.doReq(ctx, e, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return apiError(resp)
+	}
+	return nil
+}
+
 // Pins returns all pinned messages in the channel as an array of messages.
 func (r *ChannelResource) Pins(ctx context.Context) ([]Message, error) {
 	e := endpoint.GetPinnedMessages(r.channelID)

--- a/dispatch.go
+++ b/dispatch.go
@@ -7,42 +7,43 @@ import (
 )
 
 const (
-	eventHello                    = "HELLO"
-	eventReady                    = "READY"
-	eventResumed                  = "RESUMED"
-	eventInvalidSession           = "INVALID_SESSION"
-	eventChannelCreate            = "CHANNEL_CREATE"
-	eventChannelUpdate            = "CHANNEL_UPDATE"
-	eventChannelDelete            = "CHANNEL_DELETE"
-	eventChannelPinsUpdate        = "CHANNEL_PINS_UPDATE"
-	eventGuildCreate              = "GUILD_CREATE"
-	eventGuildUpdate              = "GUILD_UPDATE"
-	eventGuildDelete              = "GUILD_DELETE"
-	eventGuildBanAdd              = "GUILD_BAN_ADD"
-	eventGuildBanRemove           = "GUILD_BAN_REMOVE"
-	eventGuildEmojisUpdate        = "GUILD_EMOJIS_UPDATE"
-	eventGuildIntegrationsUpdate  = "GUILD_INTEGRATIONS_UPDATE"
-	eventGuildMemberAdd           = "GUILD_MEMBER_ADD"
-	eventGuildMemberRemove        = "GUILD_MEMBER_REMOVE"
-	eventGuildMemberUpdate        = "GUILD_MEMBER_UPDATE"
-	eventGuildMembersChunk        = "GUILD_MEMBERS_CHUNK"
-	eventGuildRoleCreate          = "GUILD_ROLE_CREATE"
-	eventGuildRoleUpdate          = "GUILD_ROLE_UPDATE"
-	eventGuildRoleDelete          = "GUILD_ROLE_DELETE"
-	eventMessageCreate            = "MESSAGE_CREATE"
-	eventMessageUpdate            = "MESSAGE_UPDATE"
-	eventMessageDelete            = "MESSAGE_DELETE"
-	eventMessageDeleteBulk        = "MESSAGE_DELETE_BULK"
-	eventMessageAck               = "MESSAGE_ACK"
-	eventMessageReactionAdd       = "MESSAGE_REACTION_ADD"
-	eventMessageReactionRemove    = "MESSAGE_REACTION_REMOVE"
-	eventMessageReactionRemoveAll = "MESSAGE_REACTION_REMOVE_ALL"
-	eventPresenceUpdate           = "PRESENCE_UPDATE"
-	eventTypingStart              = "TYPING_START"
-	eventUserUpdate               = "USER_UPDATE"
-	eventVoiceStateUpdate         = "VOICE_STATE_UPDATE"
-	eventVoiceServerUpdate        = "VOICE_SERVER_UPDATE"
-	eventWebhooksUpdate           = "WEBHOOKS_UPDATE"
+	eventHello                      = "HELLO"
+	eventReady                      = "READY"
+	eventResumed                    = "RESUMED"
+	eventInvalidSession             = "INVALID_SESSION"
+	eventChannelCreate              = "CHANNEL_CREATE"
+	eventChannelUpdate              = "CHANNEL_UPDATE"
+	eventChannelDelete              = "CHANNEL_DELETE"
+	eventChannelPinsUpdate          = "CHANNEL_PINS_UPDATE"
+	eventGuildCreate                = "GUILD_CREATE"
+	eventGuildUpdate                = "GUILD_UPDATE"
+	eventGuildDelete                = "GUILD_DELETE"
+	eventGuildBanAdd                = "GUILD_BAN_ADD"
+	eventGuildBanRemove             = "GUILD_BAN_REMOVE"
+	eventGuildEmojisUpdate          = "GUILD_EMOJIS_UPDATE"
+	eventGuildIntegrationsUpdate    = "GUILD_INTEGRATIONS_UPDATE"
+	eventGuildMemberAdd             = "GUILD_MEMBER_ADD"
+	eventGuildMemberRemove          = "GUILD_MEMBER_REMOVE"
+	eventGuildMemberUpdate          = "GUILD_MEMBER_UPDATE"
+	eventGuildMembersChunk          = "GUILD_MEMBERS_CHUNK"
+	eventGuildRoleCreate            = "GUILD_ROLE_CREATE"
+	eventGuildRoleUpdate            = "GUILD_ROLE_UPDATE"
+	eventGuildRoleDelete            = "GUILD_ROLE_DELETE"
+	eventMessageCreate              = "MESSAGE_CREATE"
+	eventMessageUpdate              = "MESSAGE_UPDATE"
+	eventMessageDelete              = "MESSAGE_DELETE"
+	eventMessageDeleteBulk          = "MESSAGE_DELETE_BULK"
+	eventMessageAck                 = "MESSAGE_ACK"
+	eventMessageReactionAdd         = "MESSAGE_REACTION_ADD"
+	eventMessageReactionRemove      = "MESSAGE_REACTION_REMOVE"
+	eventMessageReactionRemoveAll   = "MESSAGE_REACTION_REMOVE_ALL"
+	eventMessageReactionRemoveEmoji = "MESSAGE_REACTION_REMOVE_EMOJI"
+	eventPresenceUpdate             = "PRESENCE_UPDATE"
+	eventTypingStart                = "TYPING_START"
+	eventUserUpdate                 = "USER_UPDATE"
+	eventVoiceStateUpdate           = "VOICE_STATE_UPDATE"
+	eventVoiceServerUpdate          = "VOICE_SERVER_UPDATE"
+	eventWebhooksUpdate             = "WEBHOOKS_UPDATE"
 )
 
 // NOTE: consider using a map[string]sync.Pool to cache event objects.
@@ -282,6 +283,12 @@ func (c *Client) dispatch(typ string, data json.RawMessage) error {
 			return err
 		}
 		c.handle(eventMessageReactionRemoveAll, &mr)
+	case eventMessageReactionRemoveEmoji:
+		var m MessageReactionRemoveEmoji
+		if err = json.Unmarshal(data, &m); err != nil {
+			return err
+		}
+		c.handle(eventMessageReactionRemoveEmoji, &m)
 
 	case eventPresenceUpdate:
 		var p Presence

--- a/events.go
+++ b/events.go
@@ -456,6 +456,26 @@ func (c *Client) OnMessageReactionRemoveAll(f func(r *MessageReactionRemoveAll))
 	c.registerHandler(eventMessageReactionRemoveAll, messageReactionRemoveAllHandler(f))
 }
 
+type MessageReactionRemoveEmoji struct {
+	GuildID   string `json:"guild_id"`
+	ChannelID string `json:"channel_id"`
+	MessageID string `json:"message_id"`
+	Emoji     *Emoji `json:"emoji"`
+}
+
+type messageReactionRemoveEmojiHandler func(*MessageReactionRemoveEmoji)
+
+// handle implements the handler interface.
+func (h messageReactionRemoveEmojiHandler) handle(v interface{}) {
+	h(v.(*MessageReactionRemoveEmoji))
+}
+
+// HandleMessageReactionRemoveEmoji registers the handler function for the "MESSAGE_REACTION_REMOVE_ALL" event.
+// Fired when a user explicitly removes all reactions from a message.
+func (c *Client) OnMessageReactionRemoveEmoji(f func(r *MessageReactionRemoveEmoji)) {
+	c.registerHandler(eventMessageReactionRemoveEmoji, messageReactionRemoveEmojiHandler(f))
+}
+
 type presenceUpdateHandler func(*Presence)
 
 // handle implements the handler interface.

--- a/harmony_test.go
+++ b/harmony_test.go
@@ -142,11 +142,21 @@ func TestHarmony(t *testing.T) {
 		if err = client.Channel(txtCh.ID).AddReaction(context.TODO(), lastMsgID, "👎"); err != nil {
 			t.Fatalf("could not add reaction to last message: %v", err)
 		}
+
+		if err = client.Channel(txtCh.ID).AddReaction(context.TODO(), lastMsgID, "🖐️"); err != nil {
+			t.Fatalf("could not add reaction to last message: %v", err)
+		}
 	})
 
 	t.Run("remove reaction", func(t *testing.T) {
 		if err = client.Channel(txtCh.ID).RemoveReaction(context.TODO(), lastMsgID, "👎"); err != nil {
 			t.Fatalf("could not remove reaction to last message: %v", err)
+		}
+	})
+
+	t.Run("remove all reactions for emoji", func(t *testing.T) {
+		if err = client.Channel(txtCh.ID).RemoveAllReactionsForEmoji(context.TODO(), lastMsgID, "🖐"); err != nil {
+			t.Fatalf("could not remove all reactions for emoji: %v", err)
 		}
 	})
 

--- a/internal/endpoint/reaction.go
+++ b/internal/endpoint/reaction.go
@@ -34,6 +34,14 @@ func DeleteAllReactions(chID, msgID string) *Endpoint {
 	}
 }
 
+func DeleteAllReactionsForEmoji(chID, msgID, emoji string) *Endpoint {
+	return &Endpoint{
+		Method: http.MethodDelete,
+		Path:   "/channels/" + chID + "/messages/" + msgID + "/reactions/" + emoji,
+		Key:    "/channels/" + chID + "/messages",
+	}
+}
+
 func GetReactions(chID, msgID, emoji, query string) *Endpoint {
 	if query != "" {
 		query = "?" + query


### PR DESCRIPTION
### Description

This PR adds support for the Delete All Reactions for Emoji [endpoint](https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji) as well as for the corresponding [Gateway event](https://discord.com/developers/docs/topics/gateway#message-reaction-remove-emoji).

A new `RemoveAllReactionsForEmoji` method has been added to the Channel object and a new `OnMessageReactionRemoveEmoji` method has been added to the Client.