### PR TITLE
Make return types for harmony.apiError consistent

### DIFF
--- a/error.go
+++ b/error.go
@@ -94,7 +94,7 @@ func apiError(resp *http.Response) error {
 		return err
 	}
 
-	apiErr := APIError{HTTPCode: resp.StatusCode}
+	apiErr := &APIError{HTTPCode: resp.StatusCode}
 	if err = json.Unmarshal(b, &apiErr); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR makes `harmony.apiError` return pointers to errors in all cases. Before, a pointer would not be returned for an `APIError`, but a pointer would be returned for a `ValidationError` which led to some slightly confusing and unexpected behaviour that was also inconsistent with functions that called `apiError`, like [`harmony.ChannelResource.Message`](https://github.com/skwair/harmony/blob/40b27cf8c1ac3d3c113346b9d5af6cf865605a95/channel_message.go#L134).

