### PR TITLE
Add warning when trying to register an event handler with missing intent

### DIFF
--- a/discord/gateway_intent.go
+++ b/discord/gateway_intent.go
@@ -3,6 +3,11 @@ package discord
 // GatewayIntent specifies which events the Gateway should send to a client.
 type GatewayIntent int
 
+// String implements fmt.Stringer.
+func (i GatewayIntent) String() string {
+	return intentNames[i]
+}
+
 // List of gateway intents a client can subscribe to.
 const (
 	GatewayIntentGuild                  GatewayIntent = 1 << 0
@@ -24,3 +29,21 @@ const (
 
 // Equivalent to all intents except privileged (GatewayIntentGuildMembers and GatewayIntentGuildPresences), OR'd.
 const GatewayIntentUnprivileged = GatewayIntentGuild | GatewayIntentGuildBans | GatewayIntentGuildEmojis | GatewayIntentGuildIntegrations | GatewayIntentGuildWebhooks | GatewayIntentGuildInvites | GatewayIntentGuildVoiceStates | GatewayIntentGuildMessages | GatewayIntentGuildMessageReactions | GatewayIntentGuildMessageTyping | GatewayIntentDirectMessages | GatewayIntentDirectMessageReactions | GatewayIntentDirectMessageTyping
+
+var intentNames = map[GatewayIntent]string{
+	GatewayIntentGuild:                  "GUILDS",
+	GatewayIntentGuildMembers:           "GUILD_MEMBERS",
+	GatewayIntentGuildBans:              "GUILD_BANS",
+	GatewayIntentGuildEmojis:            "GUILD_EMOJIS",
+	GatewayIntentGuildIntegrations:      "GUILD_INTEGRATIONS",
+	GatewayIntentGuildWebhooks:          "GUILD_WEBHOOKS",
+	GatewayIntentGuildInvites:           "GUILD_INVITES",
+	GatewayIntentGuildVoiceStates:       "GUILD_VOICE_STATES",
+	GatewayIntentGuildPresences:         "GUILD_PRESENCES",
+	GatewayIntentGuildMessages:          "GUILD_MESSAGES",
+	GatewayIntentGuildMessageReactions:  "GUILD_MESSAGE_REACTIONS",
+	GatewayIntentGuildMessageTyping:     "GUILD_MESSAGE_TYPING",
+	GatewayIntentDirectMessages:         "DIRECT_MESSAGES",
+	GatewayIntentDirectMessageReactions: "DIRECT_MESSAGE_REACTIONS",
+	GatewayIntentDirectMessageTyping:    "DIRECT_MESSAGE_TYPING",
+}

--- a/dispatch.go
+++ b/dispatch.go
@@ -109,7 +109,6 @@ func (c *Client) dispatch(typ string, data json.RawMessage) error {
 
 	case eventGuildCreate:
 		var g discord.Guild
-		fmt.Println(string(data))
 		if err = json.Unmarshal(data, &g); err != nil {
 			return fmt.Errorf("unmarshal guild create event: %w", err)
 		}

--- a/events.go
+++ b/events.go
@@ -9,9 +9,58 @@ type handler interface {
 	handle(interface{})
 }
 
+var intents = map[string]discord.GatewayIntent{
+	eventGuildCreate:       discord.GatewayIntentGuild,
+	eventGuildUpdate:       discord.GatewayIntentGuild,
+	eventGuildRoleCreate:   discord.GatewayIntentGuild,
+	eventGuildRoleUpdate:   discord.GatewayIntentGuild,
+	eventGuildRoleDelete:   discord.GatewayIntentGuild,
+	eventChannelCreate:     discord.GatewayIntentGuild,
+	eventChannelUpdate:     discord.GatewayIntentGuild,
+	eventChannelDelete:     discord.GatewayIntentGuild,
+	eventChannelPinsUpdate: discord.GatewayIntentGuild,
+
+	eventGuildMemberAdd:    discord.GatewayIntentGuildMembers,
+	eventGuildMemberUpdate: discord.GatewayIntentGuildMembers,
+	eventGuildMemberRemove: discord.GatewayIntentGuildMembers,
+
+	eventGuildBanAdd:    discord.GatewayIntentGuildBans,
+	eventGuildBanRemove: discord.GatewayIntentGuildBans,
+
+	eventGuildEmojisUpdate: discord.GatewayIntentGuildEmojis,
+
+	eventGuildIntegrationsUpdate: discord.GatewayIntentGuildIntegrations,
+
+	eventWebhooksUpdate: discord.GatewayIntentGuildWebhooks,
+
+	eventGuildInviteCreate: discord.GatewayIntentGuildInvites,
+	eventGuildInviteDelete: discord.GatewayIntentGuildInvites,
+
+	eventVoiceStateUpdate: discord.GatewayIntentGuildVoiceStates,
+
+
+	eventPresenceUpdate: discord.GatewayIntentGuildPresences,
+
+	eventMessageCreate:     discord.GatewayIntentGuildMessages | discord.GatewayIntentDirectMessages,
+	eventMessageUpdate:     discord.GatewayIntentGuildMessages | discord.GatewayIntentDirectMessages,
+	eventMessageDelete:     discord.GatewayIntentGuildMessages | discord.GatewayIntentDirectMessages,
+	eventMessageDeleteBulk: discord.GatewayIntentGuildMessages | discord.GatewayIntentDirectMessages,
+
+	eventMessageReactionAdd:         discord.GatewayIntentGuildMessageReactions | discord.GatewayIntentDirectMessageReactions,
+	eventMessageReactionRemove:      discord.GatewayIntentGuildMessageReactions | discord.GatewayIntentDirectMessageReactions,
+	eventMessageReactionRemoveAll:   discord.GatewayIntentGuildMessageReactions | discord.GatewayIntentDirectMessageReactions,
+	eventMessageReactionRemoveEmoji: discord.GatewayIntentGuildMessageReactions | discord.GatewayIntentDirectMessageReactions,
+
+	eventTypingStart: discord.GatewayIntentGuildMessageTyping | discord.GatewayIntentDirectMessageTyping,
+}
+
 func (c *Client) registerHandler(event string, h handler) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if missing := intents[event]; missing&c.intents == 0 {
+		c.logger.Warnf("registering handler for event %q without required intent %q", event, missing)
+	}
 
 	if h == nil {
 		panic("harmony: trying to register a nil event handler")

--- a/events.go
+++ b/events.go
@@ -38,7 +38,6 @@ var intents = map[string]discord.GatewayIntent{
 
 	eventVoiceStateUpdate: discord.GatewayIntentGuildVoiceStates,
 
-
 	eventPresenceUpdate: discord.GatewayIntentGuildPresences,
 
 	eventMessageCreate:     discord.GatewayIntentGuildMessages | discord.GatewayIntentDirectMessages,


### PR DESCRIPTION
### Description

This PR adds a warning log if an event handler is registered but it doesn't have the matching intent. While it's not an error to do so strictly speaking, it is very likely an oversight.