### PR TITLE
fix discord.Time's UnmarshalJSON implementation

### DIFF
--- a/discord/time.go
+++ b/discord/time.go
@@ -1,6 +1,7 @@
 package discord
 
 import (
+	"strings"
 	"time"
 )
 
@@ -21,12 +22,15 @@ func (t Time) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (t *Time) UnmarshalJSON(data []byte) error {
-	var ts time.Time
-	if err := ts.UnmarshalJSON(data); err != nil {
+	str := string(data)
+	str = strings.ReplaceAll(str, `"`, "")
+
+	tt, err := time.Parse(time.RFC3339, str)
+	if err != nil {
 		return err
 	}
 
-	t.Time = ts
+	t.Time = tt
 	return nil
 }
 


### PR DESCRIPTION
Hey there,

I ran into a parsing error when registering a handler for `PRESENCE_UPDATE`; specifically within the `CreatedAt` field of the handled `discord.Presence`'s `Game` field. After some trial and error I realized it's due to the quotation marks within the bytes passed to the UnmarshalJSON implementation. I tested the fix I've got attached here, if there's anything I need to change do let me know; this is my first Go PR so I appreciate you bearing with me.

Thanks